### PR TITLE
Unsubscribe to balance changes

### DIFF
--- a/src/components/_cards/BridgeCard/InputAmount.tsx
+++ b/src/components/_cards/BridgeCard/InputAmount.tsx
@@ -50,7 +50,7 @@ export const InputAmount: React.FC = () => {
   const { data, error, isLoading } = useBalance({
     address: address,
     token: getAddress(sommToken.address),
-    watch: true,
+    watch: false,
   })
 
   const { isConnecting: isGrazConnecting } = useGrazAccount()

--- a/src/components/_columns/StrategyMobileColumn.tsx
+++ b/src/components/_columns/StrategyMobileColumn.tsx
@@ -1,5 +1,4 @@
 import { Text } from "@chakra-ui/react"
-import { DepositAndWithdrawButton } from "components/_buttons/DepositAndWithdrawButton"
 import { StrategySection } from "components/_tables/StrategySection"
 import { Timeline } from "data/context/homeContext"
 import { DepositModalType } from "data/hooks/useDepositModalStore"

--- a/src/components/_modals/DepositModal/SommelierTab.tsx
+++ b/src/components/_modals/DepositModal/SommelierTab.tsx
@@ -235,7 +235,7 @@ export const SommelierTab: VFC<DepositModalProps> = ({
         "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
     ), //WETH Address
     formatUnits: "wei",
-    watch: true,
+    watch: false,
   })
 
   const erc20Contract =

--- a/src/data/hooks/useUserBalances.tsx
+++ b/src/data/hooks/useUserBalances.tsx
@@ -10,7 +10,7 @@ export const useUserBalances = (config: ConfigProps) => {
     token: getAddress(config.lpToken.address),
     chainId: config.chain.wagmiId,
     formatUnits: "wei",
-    watch: true,
+    watch: false,
   })
 
   const lpTokenInfo = useToken({


### PR DESCRIPTION
If we subscribe to balance updates, because we are now multichain, we update all vault balances every .25 seconds on arbitrum vaults, compared to every 12 seconds on ethereum. This is a 50x increase and is untenable financially.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Modified balance watching behavior in various components to improve performance.
- **Chores**
	- Removed unused `DepositAndWithdrawButton` import to clean up the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->