### PR TITLE
Refine Modal Display Logic to Only Show on First Visit (SnapshotNotifyModal)

### DIFF
--- a/src/components/_modals/SnapshotNotifyModal..tsx
+++ b/src/components/_modals/SnapshotNotifyModal..tsx
@@ -1,0 +1,29 @@
+import { ModalProps, Text, Link } from "@chakra-ui/react"
+import { BaseModal } from "./BaseModal"
+import { useEffect } from "react"
+export const SnapshotNotifyModal = ({
+  isOpen,
+  onClose,
+}: Pick<ModalProps, "isOpen" | "onClose">) => {
+  useEffect(() => {
+    // Logic here if needed, e.g., analytics
+  }, [isOpen])
+
+  return (
+    <BaseModal
+      isOpen={isOpen}
+      onClose={onClose}
+      heading="Connect Wallet on Snapshot"
+    >
+      <Link
+        href="/snapshot"
+        color="white.500"
+        textDecoration="underline"
+        isExternal
+      >
+        Complete campaigns to earn bonus SOMM rewards and/or airdrop
+        points.
+      </Link>
+    </BaseModal>
+  )
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,32 @@
 import type { NextPage } from "next"
 import { PageHome } from "components/_pages/PageHome"
+import { useState, useEffect } from "react"
+import { SnapshotNotifyModal } from "components/_modals/SnapshotNotifyModal."
 
 const Home: NextPage = () => {
-  return <PageHome />
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  useEffect(() => {
+    const modalShown = localStorage.getItem("modalShown")
+    if (!modalShown) {
+      setIsModalOpen(true)
+      localStorage.setItem("modalShown", "true")
+    }
+  }, [])
+
+  const handleCloseModal = () => setIsModalOpen(false)
+
+  return (
+    <>
+      <PageHome />
+      {isModalOpen && (
+        <SnapshotNotifyModal
+          isOpen={isModalOpen}
+          onClose={handleCloseModal}
+        />
+      )}
+    </>
+  )
 }
 
 export default Home


### PR DESCRIPTION
This ticket addresses the repetitive display of the SnapshotNotifyModal on every home page visit. The fix involves modifying the modal's visibility logic to only appear on the user's first visit, using localStorage to track this state. The expected outcome is to enhance user experience by reducing redundancy and ensuring the modal is only shown once. Implementation includes updating the React state logic in the Home component and ensuring proper prop handling for isOpen and onClose. Testing will verify the modal's one-time appearance per browser session and its absence on subsequent visits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new modal prompting users to connect their wallet on Snapshot for campaign participation and rewards, with a direct link for completion. This modal appears on the user's first visit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->