### PR TITLE
Update real yield arb risks

### DIFF
--- a/src/data/strategies/real-yield-eth-arb.ts
+++ b/src/data/strategies/real-yield-eth-arb.ts
@@ -52,8 +52,10 @@ export const realYieldEthArb: CellarData = {
 
     Note that Real Yield ETH and Sommelier vaults are not open to persons or citizens of the United States and other restricted countries - for more details please refer to the Sommelier <a href="https://app.sommelier.finance/user-terms" style="textDecoration:underline"  target="_blank">User Terms</a>`,
     risks: `All Sommelier vaults contain smart contract risk and varying degrees of economic risk. Please take note of the following risks; however, this list is not exhaustive, and there may be additional risks:
-    
-    - This vault uses leverge, which means there is liquidation risk.
+
+    - 1 steth=1 weth is not hard coded in Aave on Arbitrum. There is a depeg risk for steth.
+    - Borrow rates on Aave have been far more volatile than borrow rates on Ethereum on Ethereum . 
+    - This vault uses leverage, which means there is liquidation risk.
     `,
   },
   depositTokens: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the risks section for the Real Yield ETH Arb strategy to include new risks related to stETH peg risk, volatile borrow rates on Aave, and clarified leverage liquidation risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->