### PR TITLE
Fix merkle apy calc

### DIFF
--- a/src/data/actions/common/getMerkleRewardsApy.ts
+++ b/src/data/actions/common/getMerkleRewardsApy.ts
@@ -1,14 +1,19 @@
 import { fetchCoingeckoPrice } from "queries/get-coingecko-price"
-import { ConfigProps } from "data/types"
+import { CellarNameKey, ConfigProps } from "data/types"
 import { tokenConfigMap } from "data/tokenConfig"
 import { formatUnits } from "viem"
 
-const ARB_TOKENS_IN_PERIOD = 30000
+const ARB_TOKENS_IN_PERIOD_ETH = 30000
+const ARB_TOKENS_IN_PERIOD_USD = 7500
 const PERIOD_DAYS = 7
 export const getMerkleRewardsApy = async (
   cellarContract: any,
   cellarConfig: ConfigProps
 ) => {
+  const tokensInPeriod = cellarConfig.cellarNameKey === CellarNameKey.REAL_YIELD_ETH_ARB
+    ? ARB_TOKENS_IN_PERIOD_ETH
+    : ARB_TOKENS_IN_PERIOD_USD
+
   const arbPrice = await fetchCoingeckoPrice(tokenConfigMap.ARB_ARBITRUM, "usd");
   const baseAssetPrice = await fetchCoingeckoPrice(cellarConfig.baseAsset, "usd");
   const totalValueStaked = await fetchTotalValueStaked(cellarContract);
@@ -16,7 +21,7 @@ export const getMerkleRewardsApy = async (
   const totalValueStakedInUsd =
     parseFloat(formatUnits(totalValueStaked, cellarConfig.cellar.decimals)) * Number(baseAssetPrice)
 
-  return ((ARB_TOKENS_IN_PERIOD * Number(arbPrice)) /
+  return ((tokensInPeriod * Number(arbPrice)) /
       totalValueStakedInUsd) *
     (365 / PERIOD_DAYS) *
     100

--- a/src/data/actions/common/getMerkleRewardsApy.ts
+++ b/src/data/actions/common/getMerkleRewardsApy.ts
@@ -6,12 +6,12 @@ import { formatUnits } from "viem"
 const ARB_TOKENS_IN_PERIOD = 30000
 const PERIOD_DAYS = 7
 export const getMerkleRewardsApy = async (
-  stakingContract: any,
+  cellarContract: any,
   cellarConfig: ConfigProps
 ) => {
   const arbPrice = await fetchCoingeckoPrice(tokenConfigMap.ARB_ARBITRUM, "usd");
   const baseAssetPrice = await fetchCoingeckoPrice(cellarConfig.baseAsset, "usd");
-  const totalValueStaked = await fetchTotalValueStaked(stakingContract);
+  const totalValueStaked = await fetchTotalValueStaked(cellarContract);
 
   const totalValueStakedInUsd =
     parseFloat(formatUnits(totalValueStaked, cellarConfig.cellar.decimals)) * Number(baseAssetPrice)
@@ -22,11 +22,11 @@ export const getMerkleRewardsApy = async (
     100
 }
 const fetchTotalValueStaked = async (
-  stakingContract: any
+  cellarContract: any
 ) => {
   try {
-    const totalDeposits = await stakingContract.read.totalDeposits()
-    return totalDeposits
+    const totalAssets = await cellarContract.read.totalAssets()
+    return totalAssets
   } catch (error) {
     console.error("Failed to fetch total value staked:", error)
     return BigInt(0)

--- a/src/data/actions/common/getStrategyData.ts
+++ b/src/data/actions/common/getStrategyData.ts
@@ -142,7 +142,7 @@ export const getStrategyData = async ({
 
       if (strategy.slug === utilConfig.CONTRACT.REAL_YIELD_ETH_ARB.SLUG
         || strategy.slug === utilConfig.CONTRACT.REAL_YIELD_USD_ARB.SLUG) {
-        merkleRewardsApy = await getMerkleRewardsApy(stakerContract, config);
+        merkleRewardsApy = await getMerkleRewardsApy(cellarContract, config);
       }
 
       let extraRewardsApy = undefined


### PR DESCRIPTION
ARB tokens in period ->30000 for REAL_YIELD_ETH_ARB and 7500 for REAL_YIELD_USD_ARB.

Replaced stakerContract.totalDeposits() call to cellarContract.totalAssets()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced reward calculation mechanism to differentiate between ETH and USD amounts.
  
- **Bug Fixes**
  - Corrected the parameter names for better accuracy in APY calculation.

- **Refactor**
  - Updated function calls for consistency with new naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->