### PR TITLE
Remove arbitrum yield enhancement

### DIFF
--- a/src/data/actions/common/getStrategyData.ts
+++ b/src/data/actions/common/getStrategyData.ts
@@ -140,9 +140,7 @@ export const getStrategyData = async ({
 
       let merkleRewardsApy;
 
-      if (strategy.slug === utilConfig.CONTRACT.REAL_YIELD_ETH_ARB.SLUG
-        || strategy.slug === utilConfig.CONTRACT.REAL_YIELD_USD_ARB.SLUG
-        || strategy.slug === utilConfig.CONTRACT.REAL_YIELD_ETH_OPT.SLUG) {
+      if (strategy.slug === utilConfig.CONTRACT.REAL_YIELD_ETH_OPT.SLUG) {
         merkleRewardsApy = await getMerkleRewardsApy(cellarContract, config);
       }
 


### PR DESCRIPTION
Removed Merkl rewards APY from Real Yield ETH and Real Yield USD on arbitrum.