### PR TITLE
Fix conditional hook usage in withdraw form

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@vanilla-extract/private": "^1.0.5",
     "@vanilla-extract/sprinkles": "^1.6.3",
     "@vercel/kv": "^1.0.1",
+    "@wagmi/connectors": "^5.1.0",
     "@wagmi/core": "2.14.6",
     "analytics": "^0.8.1",
     "axios": "^1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@vercel/kv':
         specifier: ^1.0.1
         version: 1.0.1
+      '@wagmi/connectors':
+        specifier: ^5.1.0
+        version: 5.7.6(@types/react@19.1.3)(@vercel/kv@1.0.1)(@wagmi/core@2.14.6(@tanstack/query-core@5.85.3)(@types/react@19.1.3)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.33.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(react@19.1.0)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.33.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       '@wagmi/core':
         specifier: 2.14.6
         version: 2.14.6(@tanstack/query-core@5.85.3)(@types/react@19.1.3)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.33.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
@@ -12349,6 +12352,45 @@ snapshots:
   '@vercel/kv@1.0.1':
     dependencies:
       '@upstash/redis': 1.25.1
+
+  '@wagmi/connectors@5.7.6(@types/react@19.1.3)(@vercel/kv@1.0.1)(@wagmi/core@2.14.6(@tanstack/query-core@5.85.3)(@types/react@19.1.3)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.33.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(react@19.1.0)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.33.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      '@coinbase/wallet-sdk': 4.2.3
+      '@metamask/sdk': 0.32.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@safe-global/safe-apps-provider': 0.18.5(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@wagmi/core': 2.14.6(@tanstack/query-core@5.85.3)(@types/react@19.1.3)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.33.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@walletconnect/ethereum-provider': 2.12.2(@types/react@19.1.3)(@vercel/kv@1.0.1)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)
+      cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
+      viem: 2.33.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - supports-color
+      - uploadthing
+      - utf-8-validate
+      - zod
 
   '@wagmi/connectors@5.7.6(@types/react@19.1.3)(@vercel/kv@1.0.1)(@wagmi/core@2.16.3(@tanstack/query-core@5.85.3)(@types/react@19.1.3)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.33.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(react@19.1.0)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.33.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
     dependencies:

--- a/src/components/_buttons/ConnectButton/ConnectedPopover.tsx
+++ b/src/components/_buttons/ConnectButton/ConnectedPopover.tsx
@@ -92,7 +92,6 @@ export const ConnectedPopover = () => {
       account: address,
     })
     disconnect()
-    window.location.reload()
   }
 
   const walletAddressIcon = () => {

--- a/src/components/_buttons/ConnectButton/MobileConnectedPopover.tsx
+++ b/src/components/_buttons/ConnectButton/MobileConnectedPopover.tsx
@@ -51,8 +51,6 @@ export const MobileConnectedPopover = () => {
     })
 
     disconnect()
-    // Refresh window
-    window.location.reload()
   }
 
   const walletAddressIcon = () => {

--- a/src/components/_forms/WithdrawForm.tsx
+++ b/src/components/_forms/WithdrawForm.tsx
@@ -147,10 +147,7 @@ export const WithdrawForm = ({ onClose }: WithdrawFormProps) => {
 
     try {
       // Alpha STETH: pre-check redeemable liquidity to avoid failing redeem tx
-      if (
-        ((useRouter().query.id as string) || _id) ===
-        config.CONTRACT.ALPHA_STETH.SLUG
-      ) {
+      if (id === config.CONTRACT.ALPHA_STETH.SLUG) {
         const redeemableAssets: number = parseInt(
           await fetchCellarRedeemableReserves(id)
         )

--- a/src/components/_pages/PageHome.tsx
+++ b/src/components/_pages/PageHome.tsx
@@ -477,7 +477,10 @@ export const PageHome = () => {
   return (
     <LayoutWithSidebar>
       <WalletHealthBanner />
-      <TopLaunchBanner targetDate={bannerTargetDate} blogHref="#" />
+      <TopLaunchBanner
+        targetDate={bannerTargetDate}
+        blogHref="https://somm.finance/blog/putting-steth-to-work-where-it-matters-most"
+      />
       {/*
         <InfoBanner
           text={

--- a/src/components/_sections/TopLaunchBanner.tsx
+++ b/src/components/_sections/TopLaunchBanner.tsx
@@ -21,7 +21,7 @@ type Props = {
 
 export default function TopLaunchBanner({
   targetDate,
-  blogHref = "#",
+  blogHref = "https://somm.finance/blog/putting-steth-to-work-where-it-matters-most",
 }: Props) {
   const lidoSrc = "/assets/images/eth-lido-uni.svg"
   const lidoFallbackPng = "/assets/icons/lido.png"
@@ -200,12 +200,7 @@ export default function TopLaunchBanner({
                   Explore Vault
                 </Button>
 
-                <Tooltip
-                  hasArrow
-                  label="Coming soon. Strategy deep‑dive will be published shortly."
-                  placement="top"
-                  openDelay={200}
-                >
+                <Link href={blogHref} isExternal _hover={{ textDecoration: "none" }}>
                   <Button
                     size="md"
                     height="40px"
@@ -217,8 +212,6 @@ export default function TopLaunchBanner({
                     color="cta.outline.fg"
                     borderColor="cta.outline.br"
                     borderWidth="2px"
-                    isDisabled
-                    pointerEvents="none"
                     _focusVisible={{
                       boxShadow:
                         "0 0 0 3px var(--chakra-colors-purple-base)",
@@ -226,7 +219,7 @@ export default function TopLaunchBanner({
                   >
                     View Strategy Blog
                   </Button>
-                </Tooltip>
+                </Link>
               </HStack>
             </Stack>
           </GridItem>

--- a/src/data/strategies/alpha-steth.ts
+++ b/src/data/strategies/alpha-steth.ts
@@ -108,7 +108,7 @@ export const alphaSteth: CellarData = {
       address: config.CONTRACT.ALPHA_STETH_LENS.ADDRESS,
       abi: config.CONTRACT.ALPHA_STETH_LENS.ABI,
     },
-    baseAsset: tokenConfigMap.WETH_ETHEREUM,
+    baseAsset: tokenConfigMap.stETH_ETHEREUM,
     withdrawTokenConfig: {
       stETH: {
         minDiscount: 1,


### PR DESCRIPTION
Fixes a bug related to React Hooks.

## Description

This PR resolves a bug where the `useRouter()` hook was being called conditionally inside the `onSubmit` function within the `WithdrawForm` component. This violates React's Rules of Hooks, which require hooks to be called at the top level of components, not inside conditional blocks or nested functions.

## Changes

- Replaced the conditional `useRouter().query.id` call within the `onSubmit` function in `src/components/_forms/WithdrawForm.tsx` with the `id` variable, which is already computed at the component's top level.

## Screenshots (if appropriate):

N/A

## Testing Steps

- [ ] Navigate to a page utilizing the `WithdrawForm` component.
- [ ] Interact with the form, specifically attempting to trigger the Alpha STETH pre-check logic (if applicable).
- [ ] Verify that the form functions correctly and no React hook-related errors appear in the console.

## Links

N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-315eca3b-b920-4d27-b959-a7d7b231657e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-315eca3b-b920-4d27-b959-a7d7b231657e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

