### PR TITLE
Remove wstETH from Alpha STETH deposit assets

### DIFF
--- a/src/data/strategies/alpha-steth.ts
+++ b/src/data/strategies/alpha-steth.ts
@@ -75,7 +75,7 @@ export const alphaSteth: CellarData = {
   dashboard:
     "https://debank.com/profile/0xef417FCE1883c6653E7dC6AF7c6F85CCDE84Aa09",
   depositTokens: {
-    list: ["WETH", "stETH", "wstETH", "ETH"],
+    list: ["WETH", "stETH", "ETH"],
   },
   config: {
     chain: chainSlugMap.ETHEREUM,


### PR DESCRIPTION
Remove wstETH from Alpha STETH depositTokens.list.\n\nChange:\n- Updated src/data/strategies/alpha-steth.ts to drop wstETH from deposit assets.\n\nChecks:\n- Lint passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Changes
  - Removed wstETH as a deposit option for the Alpha Steth strategy. Users can no longer initiate new deposits with wstETH; available deposit tokens remain WETH, stETH, and ETH. Other strategy behavior is unchanged.
- Chores
  - Updated supported token list to reflect current availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->