### PR TITLE
chore(attribution): allow sommelier.finance in allowlist

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -3,7 +3,8 @@ import type { NextRequest } from "next/server"
 
 export function middleware(req: NextRequest) {
   const host = req.headers.get("host") || req.nextUrl.host
-  if (!host || !host.endsWith("somm.finance")) {
+  const allowed = host && (host.endsWith("somm.finance") || host.endsWith("sommelier.finance"))
+  if (!allowed) {
     return new NextResponse("Forbidden", { status: 403 })
   }
 

--- a/src/pages/api/ingest-rpc.ts
+++ b/src/pages/api/ingest-rpc.ts
@@ -25,7 +25,7 @@ type RpcEvent = {
 
 function domainAllowed(host?: string) {
   if (!host) return false
-  return host.endsWith("somm.finance")
+  return host.endsWith("somm.finance") || host.endsWith("sommelier.finance")
 }
 
 function keyEvent(ts: number, id: string) {


### PR DESCRIPTION
Summary\n- Allow both *.somm.finance and *.sommelier.finance in domain allowlist.\n- Applies to middleware and /api/ingest-rpc.\n\nWhy\n- Staging domain is app-stage.sommelier.finance; previous allowlist only matched somm.finance.\n\nFiles\n- middleware.ts\n- src/pages/api/ingest-rpc.ts\n\nTesting\n1) Redeploy staging.\n2) Open https://app-stage.sommelier.finance, perform a read + a small write.\n3) In DevTools Network, filter  and confirm POST 200.\n4) Verify report:\n   curl -s "https://app-stage.sommelier.finance/api/rpc-report?from=2025-09-05&to=2025-09-05&wallet=0xYOUR_WALLET&limit=1000&format=json" | jq .\n\nImpact\n- No behavioral change for somm.finance; staging is now permitted.\n- Security posture unchanged (still scoped to our domains).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for accessing the app and APIs via sommelier.finance in addition to somm.finance.

* **Bug Fixes**
  * Resolved unexpected 403 errors when visiting or calling APIs from the sommelier.finance domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->