### PR TITLE
fix(attribution): lowercase indexing + staging allowlist ready

### DIFF
--- a/src/pages/api/ingest-rpc.ts
+++ b/src/pages/api/ingest-rpc.ts
@@ -25,7 +25,10 @@ type RpcEvent = {
 
 function domainAllowed(host?: string) {
   if (!host) return false
-  return host.endsWith("somm.finance") || host.endsWith("sommelier.finance")
+  return (
+    host.endsWith("somm.finance") ||
+    host.endsWith("sommelier.finance")
+  )
 }
 
 function keyEvent(ts: number, id: string) {
@@ -73,6 +76,9 @@ export default async function handler(
 
   const pipeline: Array<Promise<unknown>> = []
   for (const evt of events) {
+    // normalize addresses to lowercase for indexing
+    if (evt.wallet) evt.wallet = evt.wallet.toLowerCase()
+    if (evt.to) evt.to = evt.to.toLowerCase()
     const id = ulidLike()
     const key = keyEvent(evt.timestampMs || Date.now(), id)
     pipeline.push(setJson(key, evt))
@@ -94,7 +100,7 @@ export default async function handler(
     if (evt.to) {
       pipeline.push(
         zadd(
-          `rpc:index:contract:${evt.to.toLowerCase()}:${day}`,
+          `rpc:index:contract:${evt.to}:${day}`,
           evt.timestampMs,
           key
         )

--- a/src/pages/api/rpc-report.ts
+++ b/src/pages/api/rpc-report.ts
@@ -23,7 +23,7 @@ export default async function handler(
 
   const from = parseDate(String(req.query.from || ""))
   const to = parseDate(String(req.query.to || ""))
-  const wallet = (req.query.wallet as string) || undefined
+  const wallet = (req.query.wallet as string)?.toLowerCase() || undefined
   const contract =
     (req.query.contract as string)?.toLowerCase() || undefined
   const address =


### PR DESCRIPTION
Changes\n- Normalize addresses to lowercase in ingestion and reporting indices.\n- Previously merged allowlist for *.sommelier.finance (PR #1805).\n\nWhy\n- Ensure wallet/contract indices are consistent and report queries match user input.\n\nTesting after deploy\n1) Open app-stage.sommelier.finance and perform a small write.\n2) Confirm POST /api/ingest-rpc = 200 in Network.\n3) Verify rows:\n   curl -s "https://app-stage.sommelier.finance/api/rpc-report?from=2025-09-05&to=2025-09-05&wallet=0x1222f0baA62e2282Bfd01083C7C3732A8c611584&limit=1000&format=json" | jq .\n   curl -s "https://app-stage.sommelier.finance/api/rpc-report?from=2025-09-05&to=2025-09-05&contract=0x0baab6db8d694e1511992b504476ef4073fe614b&limit=1000&format=json" | jq .\n\nNotes\n- Indices now use lowercase; reporting normalizes inputs.\n- No behavior change to CSV/JSON output.