### PR TITLE
ux(alpha-steth): show Tokens as GG shares (match Withdraw modal)

### DIFF
--- a/src/components/_cards/PortfolioCard/index.tsx
+++ b/src/components/_cards/PortfolioCard/index.tsx
@@ -431,10 +431,10 @@ export const PortfolioCard = (props: BoxProps) => {
                   (isConnected
                     ? (lpTokenData &&
                         toEther(
-                          lpTokenData.formatted,
+                          lpTokenData.value,
                           lpTokenData.decimals,
-                          true,
-                          2
+                          false,
+                          6
                         )) ||
                       "..."
                     : "--")}


### PR DESCRIPTION
This PR fixes the Alpha stETH manage page Tokens metric so it displays GG shares exactly like the Withdraw modal’s "Available" line.

What changed
- Source: Reuse lpToken (GG shares) from useUserBalance(cellarConfig)
- Formatter: toEther(value, decimals, false, 6) — same precision/behavior as modal
- Loading/disconnected fallbacks preserved ("..." / "--")

Scope
- UI-only; no business logic, contracts, RPC, or routing changes
- Touches only the PortfolioCard index.tsx where the Tokens metric is rendered

Acceptance
- With wallet 0xC3B3…81Cd, Tokens shows ~0.000862 (not 0.00), matching the modal
- Other metrics unaffected; lint/typecheck pass
