### PR TITLE
Feat/alpha apy tooltip autoscroll faqs

### DIFF
--- a/src/components/AlphaStethBreakdown.tsx
+++ b/src/components/AlphaStethBreakdown.tsx
@@ -1,0 +1,124 @@
+import React from "react"
+import {
+  Box,
+  HStack,
+  VStack,
+  Text,
+  Button,
+  useDisclosure,
+} from "@chakra-ui/react"
+import { alphaStethI18n } from "i18n/alphaSteth"
+
+export type AlphaApyParts = {
+  baseApy: number
+  boostApy: number
+  feesImpact: number // negative or 0
+  netApy: number
+  updatedAt?: string
+  approximate?: boolean
+}
+
+export function AlphaStethBreakdown({ parts }: { parts: AlphaApyParts }) {
+  const { isOpen, onToggle } = useDisclosure()
+  const totalPos = Math.max(0, parts.baseApy) + Math.max(0, parts.boostApy)
+  const basePct = totalPos ? (Math.max(0, parts.baseApy) / totalPos) * 100 : 0
+  const boostPct = totalPos ? (Math.max(0, parts.boostApy) / totalPos) * 100 : 0
+
+  return (
+    <VStack spacing={2} align="stretch">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        aria-controls="alpha-apy-breakdown"
+        _hover={{ bg: "whiteAlpha.100" }}
+      >
+        {alphaStethI18n.breakdownLink}
+      </Button>
+
+      {isOpen && (
+        <VStack
+          id="alpha-apy-breakdown"
+          align="stretch"
+          spacing={3}
+          role="region"
+        >
+          {/* Stacked bar */}
+          <HStack
+            spacing={0}
+            h="10px"
+            w="100%"
+            bg="whiteAlpha.100"
+            borderRadius="full"
+            overflow="hidden"
+          >
+            <Box w={`${basePct}%`} h="100%" bg="purple.600" />
+            <Box w={`${boostPct}%`} h="100%" bg="purple.400" />
+          </HStack>
+
+          {/* Legend */}
+          <VStack align="stretch" spacing={1}>
+            <HStack justify="space-between">
+              <HStack>
+                <Box boxSize="10px" bg="purple.600" borderRadius="sm" />
+                <Text>{alphaStethI18n.breakdownItems.lidoBase}</Text>
+              </HStack>
+              <Text fontWeight={600}>{pct(parts.baseApy)}</Text>
+            </HStack>
+
+            <HStack justify="space-between">
+              <HStack>
+                <Box boxSize="10px" bg="purple.400" borderRadius="sm" />
+                <Text>{alphaStethI18n.breakdownItems.strategyBoost}</Text>
+              </HStack>
+              <Text fontWeight={600}>{pct(parts.boostApy)}</Text>
+            </HStack>
+
+            <HStack justify="space-between">
+              <HStack>
+                <Box boxSize="10px" bg="gray.500" borderRadius="sm" />
+                <Text>Fees</Text>
+              </HStack>
+              <Text fontWeight={700} color="gray.300">
+                {pct(parts.feesImpact)}
+              </Text>
+            </HStack>
+          </VStack>
+
+          <Text fontSize="xs" color="gray.400">
+            {[
+              parts.updatedAt
+                ? `Updated ${new Date(parts.updatedAt).toLocaleString()}`
+                : null,
+              "Values are variable",
+              parts.approximate ? "Some parts are estimated." : null,
+            ]
+              .filter(Boolean)
+              .join(" • ")}
+          </Text>
+
+          <Text
+            as="a"
+            href={alphaStethI18n.tooltipLinkHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            textDecoration="underline"
+            fontSize="sm"
+          >
+            {alphaStethI18n.tooltipLinkText}
+          </Text>
+        </VStack>
+      )}
+    </VStack>
+  )
+}
+
+function pct(n: number) {
+  const rounded = Math.round(n * 10) / 10
+  const sign = rounded < 0 ? "-" : ""
+  const abs = Math.abs(rounded).toFixed(1)
+  return `${sign}${abs}%`
+}
+
+

--- a/src/components/CellarStatsYield.tsx
+++ b/src/components/CellarStatsYield.tsx
@@ -12,6 +12,7 @@ import {
 import { CardDivider } from "./_layout/CardDivider"
 import { CardHeading } from "./_typography/CardHeading"
 import { InformationIcon } from "./_icons"
+import { AlphaApyPopover } from "components/alpha/AlphaApyPopover"
 import { Apy } from "./Apy"
 import { cellarDataMap } from "data/cellarDataMap"
 import { isFuture } from "date-fns"
@@ -150,25 +151,16 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
             }
           />
           <Box>
-            <Tooltip
-              hasArrow
-              placement="top"
-              label={
-                isAlpha ? (
-                  <VStack align="start" spacing={1} maxW="320px">
-                    <Text fontWeight="semibold">{alphaStethI18n.netApyLabel}</Text>
-                    <Text whiteSpace="pre-line">{alphaStethI18n.tooltipBody}</Text>
-                    <Text
-                      as="a"
-                      href={alphaStethI18n.tooltipLinkHref}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      textDecor="underline"
-                    >
-                      {alphaStethI18n.tooltipLinkText}
-                    </Text>
-                  </VStack>
-                ) : (
+            {isAlpha ? (
+              <HStack spacing={2} align="center">
+                <CardHeading>{alphaStethI18n.netApyLabel}</CardHeading>
+                <AlphaApyPopover />
+              </HStack>
+            ) : (
+              <Tooltip
+                hasArrow
+                placement="top"
+                label={
                   <>
                     <Text>
                       {apyHoverLabel(cellarConfig)} {baseApy?.formatted ?? "0.00%"}
@@ -199,20 +191,16 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
                       </>
                     )}
                   </>
-                )
-              }
-              bg="surface.bg"
-              color="neutral.300"
-            >
-              <HStack spacing={2} align="center">
-                <CardHeading>
-                  {isAlpha
-                    ? `${alphaStethI18n.netApyLabel}`
-                    : apyLabel(cellarConfig)}
-                </CardHeading>
-                <InformationIcon color="neutral.300" boxSize={3} />
-              </HStack>
-            </Tooltip>
+                }
+                bg="surface.bg"
+                color="neutral.300"
+              >
+                <HStack spacing={2} align="center">
+                  <CardHeading>{apyLabel(cellarConfig)}</CardHeading>
+                  <InformationIcon color="neutral.300" boxSize={3} />
+                </HStack>
+              </Tooltip>
+            )}
           </Box>
           {isAlpha && <AlphaStethBreakdown parts={alphaParts} />}
         </VStack>

--- a/src/components/CellarStatsYield.tsx
+++ b/src/components/CellarStatsYield.tsx
@@ -16,6 +16,8 @@ import { Apy } from "./Apy"
 import { cellarDataMap } from "data/cellarDataMap"
 import { isFuture } from "date-fns"
 import { apyHoverLabel, apyLabel } from "data/uiConfig"
+import { config as utilConfig } from "utils/config"
+import { alphaStethI18n } from "i18n/alphaSteth"
 import { useStrategyData } from "data/hooks/useStrategyData"
 
 // Define an interface for APY data which includes the optional 'formatted' property
@@ -25,10 +27,13 @@ interface ApyData {
 
 interface CellarStatsYieldProps extends StackProps {
   cellarId: string
+  /** When true, applies Alpha stETH-specific label/tooltip/footnote */
+  alphaStethOverrides?: boolean
 }
 
 export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
   cellarId,
+  alphaStethOverrides,
   ...rest
 }) => {
   const cellarConfig = cellarDataMap[cellarId].config
@@ -62,6 +67,9 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
 
 
   const baseApySumRewards = strategyData?.baseApySumRewards
+  const isAlpha =
+    alphaStethOverrides ||
+    cellarId === utilConfig.CONTRACT.ALPHA_STETH.SLUG
 
   return (
     <HStack
@@ -111,59 +119,58 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
               hasArrow
               placement="top"
               label={
-                <>
-                  <Text>
-                    {apyHoverLabel(cellarConfig)}{" "}
-                    {baseApy?.formatted ?? "0.00%"}
-                  </Text>
-                  {cellarConfig.customReward?.showOnlyBaseApy !==
-                    undefined &&
-                  cellarConfig.customReward?.showOnlyBaseApy ===
-                    true ? (
-                    <></>
-                  ) : (
-                    <>
-                      <Text>
-                        {cellarConfig.customReward?.showSommRewards
-                          ? `SOMM Rewards APY ${
-                              rewardsApy?.formatted ?? "0.00%"
-                            }`
-                          : null}
-                      </Text>
-                      <Text>
-                        {cellarConfig.customReward
-                          ?.customRewardAPYTooltip ??
-                          `${
-                            cellarConfig.customReward?.showAPY
-                              ? `${cellarConfig.customReward.tokenDisplayName} `
-                              : ""
-                          }Rewards APY ${
-                            extraRewardsApy?.formatted ??
-                            rewardsApy?.formatted ??
-                            "0.00%"
-                          }`}
-                      </Text>
-                      {/* <Text>
-                        {merkleRewardsApy
-                          ? `Merkle Rewards APY ${merkleRewardsApy.toFixed(2)}%`
-                          : ''
-                          }
-                      </Text> */}
-                    </>
-                  )}
-                </>
+                isAlpha ? (
+                  <VStack align="start" spacing={1} maxW="280px">
+                    <Text fontWeight="semibold">
+                      {alphaStethI18n.tooltipTitle}
+                    </Text>
+                    <Text>{alphaStethI18n.tooltipBody}</Text>
+                    <Text as="a" href={alphaStethI18n.tooltipLinkHref} target="_blank" rel="noopener noreferrer" textDecor="underline">
+                      {alphaStethI18n.tooltipLinkText}
+                    </Text>
+                  </VStack>
+                ) : (
+                  <>
+                    <Text>
+                      {apyHoverLabel(cellarConfig)} {baseApy?.formatted ?? "0.00%"}
+                    </Text>
+                    {cellarConfig.customReward?.showOnlyBaseApy !== undefined &&
+                    cellarConfig.customReward?.showOnlyBaseApy === true ? (
+                      <></>
+                    ) : (
+                      <>
+                        <Text>
+                          {cellarConfig.customReward?.showSommRewards
+                            ? `SOMM Rewards APY ${rewardsApy?.formatted ?? "0.00%"}`
+                            : null}
+                        </Text>
+                        <Text>
+                          {cellarConfig.customReward?.customRewardAPYTooltip ??
+                            `${cellarConfig.customReward?.showAPY ? `${cellarConfig.customReward.tokenDisplayName} ` : ""}Rewards APY ${
+                              extraRewardsApy?.formatted ?? rewardsApy?.formatted ?? "0.00%"
+                            }`}
+                        </Text>
+                      </>
+                    )}
+                  </>
+                )
               }
               bg="surface.bg"
               color="neutral.300"
             >
               <HStack spacing={1} align="center">
-                <CardHeading>{apyLabel(cellarConfig)}</CardHeading>
+                <CardHeading>{isAlpha ? alphaStethI18n.netApyLabel : apyLabel(cellarConfig)}</CardHeading>
                 {!!apyLabel(cellarConfig) && (
                   <InformationIcon color="neutral.300" boxSize={3} />
                 )}
               </HStack>
             </Tooltip>
           </Box>
+          {isAlpha && (
+            <Text fontSize="xs" color="neutral.400" textAlign="center" maxW="280px">
+              {alphaStethI18n.footnote}
+            </Text>
+          )}
         </VStack>
       )}
     </HStack>

--- a/src/components/CellarStatsYield.tsx
+++ b/src/components/CellarStatsYield.tsx
@@ -12,7 +12,6 @@ import {
 import { CardDivider } from "./_layout/CardDivider"
 import { CardHeading } from "./_typography/CardHeading"
 import { InformationIcon } from "./_icons"
-import { AlphaApyTooltip } from "components/alpha/AlphaApyTooltip"
 import { Apy } from "./Apy"
 import { cellarDataMap } from "data/cellarDataMap"
 import { isFuture } from "date-fns"
@@ -25,6 +24,8 @@ import {
   type AlphaApyParts,
 } from "components/AlphaStethBreakdown"
 import { useStrategyData } from "data/hooks/useStrategyData"
+import { AlphaApyTooltip } from "components/alpha/AlphaApyTooltip"
+import { KpiLabelWithInfo } from "components/alpha/KpiLabelWithInfo"
 
 // Define an interface for APY data which includes the optional 'formatted' property
 interface ApyData {
@@ -149,35 +150,26 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
             }
           />
           <Box>
-            <Tooltip
-              hasArrow
-              placement="top"
-              label={
-                isAlpha ? (
-                  <VStack align="start" spacing={1} maxW="320px">
-                    <Text fontSize="sm">
-                      {alphaStethI18n.tooltipBody}
-                    </Text>
-                    <Text
-                      as="a"
-                      href={alphaStethI18n.tooltipLinkHref}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      textDecor="underline"
-                    >
-                      {alphaStethI18n.tooltipLinkText}
-                    </Text>
-                  </VStack>
-                ) : (
+            {isAlpha ? (
+              <VStack spacing={2} align="center">
+                <AlphaApyTooltip>
+                  <KpiLabelWithInfo
+                    label={alphaStethI18n.netApyLabel}
+                    aria-label="About Net APY"
+                  />
+                </AlphaApyTooltip>
+              </VStack>
+            ) : (
+              <Tooltip
+                hasArrow
+                placement="top"
+                label={
                   <>
                     <Text>
-                      {apyHoverLabel(cellarConfig)}{" "}
-                      {baseApy?.formatted ?? "0.00%"}
+                      {apyHoverLabel(cellarConfig)} {baseApy?.formatted ?? "0.00%"}
                     </Text>
-                    {cellarConfig.customReward?.showOnlyBaseApy !==
-                      undefined &&
-                    cellarConfig.customReward?.showOnlyBaseApy ===
-                      true ? (
+                    {cellarConfig.customReward?.showOnlyBaseApy !== undefined &&
+                    cellarConfig.customReward?.showOnlyBaseApy === true ? (
                       <></>
                     ) : (
                       <>
@@ -189,39 +181,29 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
                             : null}
                         </Text>
                         <Text>
-                          {cellarConfig.customReward
-                            ?.customRewardAPYTooltip ??
-                            `${
-                              cellarConfig.customReward?.showAPY
-                                ? `${cellarConfig.customReward.tokenDisplayName} `
-                                : ""
-                            }Rewards APY ${
-                              extraRewardsApy?.formatted ??
-                              rewardsApy?.formatted ??
-                              "0.00%"
-                            }`}
+                          {cellarConfig.customReward?.customRewardAPYTooltip ?? `${
+                            cellarConfig.customReward?.showAPY
+                              ? `${cellarConfig.customReward.tokenDisplayName} `
+                              : ""
+                          }Rewards APY ${
+                            extraRewardsApy?.formatted ??
+                            rewardsApy?.formatted ??
+                            "0.00%"
+                          }`}
                         </Text>
                       </>
                     )}
                   </>
-                )
-              }
-              bg="surface.bg"
-              color="neutral.300"
-            >
-              <HStack spacing={2} align="center">
-                <CardHeading>
-                  {isAlpha
-                    ? `${alphaStethI18n.netApyLabel}`
-                    : apyLabel(cellarConfig)}
-                </CardHeading>
-                {isAlpha ? (
-                  <AlphaApyTooltip />
-                ) : (
+                }
+                bg="surface.bg"
+                color="neutral.300"
+              >
+                <HStack spacing={2} align="center">
+                  <CardHeading>{apyLabel(cellarConfig)}</CardHeading>
                   <InformationIcon color="neutral.300" boxSize={3} />
-                )}
-              </HStack>
-            </Tooltip>
+                </HStack>
+              </Tooltip>
+            )}
           </Box>
           {isAlpha && <AlphaStethBreakdown parts={alphaParts} />}
         </VStack>

--- a/src/components/CellarStatsYield.tsx
+++ b/src/components/CellarStatsYield.tsx
@@ -150,60 +150,51 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
             }
           />
           <Box>
-            {isAlpha ? (
-              <VStack spacing={2} align="center">
-                <AlphaApyTooltip>
-                  <KpiLabelWithInfo
-                    label={alphaStethI18n.netApyLabel}
-                    aria-label="About Net APY"
-                  />
-                </AlphaApyTooltip>
-              </VStack>
-            ) : (
-              <Tooltip
-                hasArrow
-                placement="top"
-                label={
-                  <>
-                    <Text>
-                      {apyHoverLabel(cellarConfig)} {baseApy?.formatted ?? "0.00%"}
-                    </Text>
-                    {cellarConfig.customReward?.showOnlyBaseApy !== undefined &&
-                    cellarConfig.customReward?.showOnlyBaseApy === true ? (
-                      <></>
-                    ) : (
-                      <>
-                        <Text>
-                          {cellarConfig.customReward?.showSommRewards
-                            ? `SOMM Rewards APY ${
-                                rewardsApy?.formatted ?? "0.00%"
-                              }`
-                            : null}
-                        </Text>
-                        <Text>
-                          {cellarConfig.customReward?.customRewardAPYTooltip ?? `${
-                            cellarConfig.customReward?.showAPY
-                              ? `${cellarConfig.customReward.tokenDisplayName} `
-                              : ""
-                          }Rewards APY ${
-                            extraRewardsApy?.formatted ??
-                            rewardsApy?.formatted ??
-                            "0.00%"
-                          }`}
-                        </Text>
-                      </>
-                    )}
-                  </>
-                }
-                bg="surface.bg"
-                color="neutral.300"
-              >
-                <HStack spacing={2} align="center">
-                  <CardHeading>{apyLabel(cellarConfig)}</CardHeading>
-                  <InformationIcon color="neutral.300" boxSize={3} />
-                </HStack>
-              </Tooltip>
-            )}
+            <Tooltip
+              hasArrow
+              placement="top"
+              label={
+                <>
+                  <Text>
+                    {apyHoverLabel(cellarConfig)} {baseApy?.formatted ?? "0.00%"}
+                  </Text>
+                  {cellarConfig.customReward?.showOnlyBaseApy !== undefined &&
+                  cellarConfig.customReward?.showOnlyBaseApy === true ? (
+                    <></>
+                  ) : (
+                    <>
+                      <Text>
+                        {cellarConfig.customReward?.showSommRewards
+                          ? `SOMM Rewards APY ${
+                              rewardsApy?.formatted ?? "0.00%"
+                            }`
+                          : null}
+                      </Text>
+                      <Text>
+                        {cellarConfig.customReward?.customRewardAPYTooltip ?? `${
+                          cellarConfig.customReward?.showAPY
+                            ? `${cellarConfig.customReward.tokenDisplayName} `
+                            : ""
+                        }Rewards APY ${
+                          extraRewardsApy?.formatted ??
+                          rewardsApy?.formatted ??
+                          "0.00%"
+                        }`}
+                      </Text>
+                    </>
+                  )}
+                </>
+              }
+              bg="surface.bg"
+              color="neutral.300"
+            >
+              <HStack spacing={2} align="center">
+                <CardHeading>
+                  {isAlpha ? `${alphaStethI18n.netApyLabel}` : apyLabel(cellarConfig)}
+                </CardHeading>
+                <InformationIcon color="neutral.300" boxSize={3} />
+              </HStack>
+            </Tooltip>
           </Box>
           {isAlpha && <AlphaStethBreakdown parts={alphaParts} />}
         </VStack>

--- a/src/components/CellarStatsYield.tsx
+++ b/src/components/CellarStatsYield.tsx
@@ -154,43 +154,61 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
               hasArrow
               placement="top"
               label={
-                <>
-                  <Text>
-                    {apyHoverLabel(cellarConfig)} {baseApy?.formatted ?? "0.00%"}
-                  </Text>
-                  {cellarConfig.customReward?.showOnlyBaseApy !== undefined &&
-                  cellarConfig.customReward?.showOnlyBaseApy === true ? (
-                    <></>
-                  ) : (
-                    <>
-                      <Text>
-                        {cellarConfig.customReward?.showSommRewards
-                          ? `SOMM Rewards APY ${
-                              rewardsApy?.formatted ?? "0.00%"
-                            }`
-                          : null}
-                      </Text>
-                      <Text>
-                        {cellarConfig.customReward?.customRewardAPYTooltip ?? `${
-                          cellarConfig.customReward?.showAPY
-                            ? `${cellarConfig.customReward.tokenDisplayName} `
-                            : ""
-                        }Rewards APY ${
-                          extraRewardsApy?.formatted ??
-                          rewardsApy?.formatted ??
-                          "0.00%"
-                        }`}
-                      </Text>
-                    </>
-                  )}
-                </>
+                isAlpha ? (
+                  <VStack align="start" spacing={1} maxW="320px">
+                    <Text fontWeight="semibold">{alphaStethI18n.netApyLabel}</Text>
+                    <Text whiteSpace="pre-line">{alphaStethI18n.tooltipBody}</Text>
+                    <Text
+                      as="a"
+                      href={alphaStethI18n.tooltipLinkHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      textDecor="underline"
+                    >
+                      {alphaStethI18n.tooltipLinkText}
+                    </Text>
+                  </VStack>
+                ) : (
+                  <>
+                    <Text>
+                      {apyHoverLabel(cellarConfig)} {baseApy?.formatted ?? "0.00%"}
+                    </Text>
+                    {cellarConfig.customReward?.showOnlyBaseApy !== undefined &&
+                    cellarConfig.customReward?.showOnlyBaseApy === true ? (
+                      <></>
+                    ) : (
+                      <>
+                        <Text>
+                          {cellarConfig.customReward?.showSommRewards
+                            ? `SOMM Rewards APY ${
+                                rewardsApy?.formatted ?? "0.00%"
+                              }`
+                            : null}
+                        </Text>
+                        <Text>
+                          {cellarConfig.customReward?.customRewardAPYTooltip ?? `${
+                            cellarConfig.customReward?.showAPY
+                              ? `${cellarConfig.customReward.tokenDisplayName} `
+                              : ""
+                          }Rewards APY ${
+                            extraRewardsApy?.formatted ??
+                            rewardsApy?.formatted ??
+                            "0.00%"
+                          }`}
+                        </Text>
+                      </>
+                    )}
+                  </>
+                )
               }
               bg="surface.bg"
               color="neutral.300"
             >
               <HStack spacing={2} align="center">
                 <CardHeading>
-                  {isAlpha ? `${alphaStethI18n.netApyLabel}` : apyLabel(cellarConfig)}
+                  {isAlpha
+                    ? `${alphaStethI18n.netApyLabel}`
+                    : apyLabel(cellarConfig)}
                 </CardHeading>
                 <InformationIcon color="neutral.300" boxSize={3} />
               </HStack>

--- a/src/components/CellarStatsYield.tsx
+++ b/src/components/CellarStatsYield.tsx
@@ -18,7 +18,7 @@ import { isFuture } from "date-fns"
 import { apyHoverLabel, apyLabel } from "data/uiConfig"
 import { config as utilConfig } from "utils/config"
 import { alphaStethI18n } from "i18n/alphaSteth"
-import { formatAlphaStethNetApy } from "utils/alphaStethFormat"
+import { formatAlphaStethNetApyNoApprox } from "utils/alphaStethFormat"
 import { AlphaStethBreakdown, type AlphaApyParts } from "components/AlphaStethBreakdown"
 import { useStrategyData } from "data/hooks/useStrategyData"
 
@@ -75,7 +75,7 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
   const approxApy = useMemo(() => {
     const raw = baseApySumRewards?.formatted
     if (!raw) return undefined
-    return formatAlphaStethNetApy(raw)
+    return formatAlphaStethNetApyNoApprox(raw)
   }, [baseApySumRewards?.formatted])
   const alphaParts: AlphaApyParts = useMemo(() => {
     const parsePct = (s?: string) => {
@@ -133,11 +133,8 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
               placement="top"
               label={
                 isAlpha ? (
-                  <VStack align="start" spacing={1} maxW="280px">
-                    <Text fontWeight="semibold">
-                      {alphaStethI18n.tooltipTitle}
-                    </Text>
-                    <Text>{alphaStethI18n.tooltipBody}</Text>
+                  <VStack align="start" spacing={1} maxW="320px">
+                    <Text fontSize="sm">{alphaStethI18n.tooltipBody}</Text>
                     <Text as="a" href={alphaStethI18n.tooltipLinkHref} target="_blank" rel="noopener noreferrer" textDecor="underline">
                       {alphaStethI18n.tooltipLinkText}
                     </Text>
@@ -176,22 +173,11 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
                   {isAlpha ? `${alphaStethI18n.netApyLabel}` : apyLabel(cellarConfig)}
                 </CardHeading>
                 <InformationIcon color="neutral.300" boxSize={3} />
-                {isAlpha && (
-                  <Text as="span" fontSize="xs" color="neutral.300">
-                    ({alphaStethI18n.estimatedTag}, variable)
-                  </Text>
-                )}
+                {null}
               </HStack>
             </Tooltip>
           </Box>
-          {isAlpha && (
-            <VStack spacing={2} align="stretch" w="full">
-              <Text fontSize="xs" color="neutral.400" textAlign="center" maxW="280px" mx="auto">
-                {alphaStethI18n.inlineMicrocopy}
-              </Text>
-              <AlphaStethBreakdown parts={alphaParts} />
-            </VStack>
-          )}
+          {isAlpha && <AlphaStethBreakdown parts={alphaParts} />}
         </VStack>
       )}
     </HStack>

--- a/src/components/CellarStatsYield.tsx
+++ b/src/components/CellarStatsYield.tsx
@@ -12,6 +12,7 @@ import {
 import { CardDivider } from "./_layout/CardDivider"
 import { CardHeading } from "./_typography/CardHeading"
 import { InformationIcon } from "./_icons"
+import { AlphaApyTooltip } from "components/alpha/AlphaApyTooltip"
 import { Apy } from "./Apy"
 import { cellarDataMap } from "data/cellarDataMap"
 import { isFuture } from "date-fns"
@@ -19,7 +20,10 @@ import { apyHoverLabel, apyLabel } from "data/uiConfig"
 import { config as utilConfig } from "utils/config"
 import { alphaStethI18n } from "i18n/alphaSteth"
 import { formatAlphaStethNetApyNoApprox } from "utils/alphaStethFormat"
-import { AlphaStethBreakdown, type AlphaApyParts } from "components/AlphaStethBreakdown"
+import {
+  AlphaStethBreakdown,
+  type AlphaApyParts,
+} from "components/AlphaStethBreakdown"
 import { useStrategyData } from "data/hooks/useStrategyData"
 
 // Define an interface for APY data which includes the optional 'formatted' property
@@ -63,10 +67,10 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
   const extraRewardsApy: ApyData = strategyData?.extraRewardsApy
     ? (strategyData.extraRewardsApy as ApyData)
     : { formatted: undefined }
-  const merkleRewardsApy: number | undefined = strategyData?.merkleRewardsApy
-    ? (strategyData.merkleRewardsApy)
-    : undefined
-
+  const merkleRewardsApy: number | undefined =
+    strategyData?.merkleRewardsApy
+      ? strategyData.merkleRewardsApy
+      : undefined
 
   const baseApySumRewards = strategyData?.baseApySumRewards
   const isAlpha =
@@ -85,12 +89,19 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
     }
     return {
       baseApy: parsePct(baseApy?.formatted),
-      boostApy: parsePct(extraRewardsApy?.formatted ?? rewardsApy?.formatted),
+      boostApy: parsePct(
+        extraRewardsApy?.formatted ?? rewardsApy?.formatted
+      ),
       feesImpact: 0,
       netApy: parsePct(baseApySumRewards?.formatted),
       approximate: true,
     }
-  }, [baseApy?.formatted, extraRewardsApy?.formatted, rewardsApy?.formatted, baseApySumRewards?.formatted])
+  }, [
+    baseApy?.formatted,
+    extraRewardsApy?.formatted,
+    rewardsApy?.formatted,
+    baseApySumRewards?.formatted,
+  ])
 
   return (
     <HStack
@@ -126,7 +137,17 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
       </VStack>
       {baseApySumRewards && (
         <VStack spacing={1} align="center">
-          <Apy apy={isStrategyLoading ? <Spinner /> : isAlpha ? approxApy ?? baseApySumRewards?.formatted : baseApySumRewards?.formatted} />
+          <Apy
+            apy={
+              isStrategyLoading ? (
+                <Spinner />
+              ) : isAlpha ? (
+                approxApy ?? baseApySumRewards?.formatted
+              ) : (
+                baseApySumRewards?.formatted
+              )
+            }
+          />
           <Box>
             <Tooltip
               hasArrow
@@ -134,30 +155,50 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
               label={
                 isAlpha ? (
                   <VStack align="start" spacing={1} maxW="320px">
-                    <Text fontSize="sm">{alphaStethI18n.tooltipBody}</Text>
-                    <Text as="a" href={alphaStethI18n.tooltipLinkHref} target="_blank" rel="noopener noreferrer" textDecor="underline">
+                    <Text fontSize="sm">
+                      {alphaStethI18n.tooltipBody}
+                    </Text>
+                    <Text
+                      as="a"
+                      href={alphaStethI18n.tooltipLinkHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      textDecor="underline"
+                    >
                       {alphaStethI18n.tooltipLinkText}
                     </Text>
                   </VStack>
                 ) : (
                   <>
                     <Text>
-                      {apyHoverLabel(cellarConfig)} {baseApy?.formatted ?? "0.00%"}
+                      {apyHoverLabel(cellarConfig)}{" "}
+                      {baseApy?.formatted ?? "0.00%"}
                     </Text>
-                    {cellarConfig.customReward?.showOnlyBaseApy !== undefined &&
-                    cellarConfig.customReward?.showOnlyBaseApy === true ? (
+                    {cellarConfig.customReward?.showOnlyBaseApy !==
+                      undefined &&
+                    cellarConfig.customReward?.showOnlyBaseApy ===
+                      true ? (
                       <></>
                     ) : (
                       <>
                         <Text>
                           {cellarConfig.customReward?.showSommRewards
-                            ? `SOMM Rewards APY ${rewardsApy?.formatted ?? "0.00%"}`
+                            ? `SOMM Rewards APY ${
+                                rewardsApy?.formatted ?? "0.00%"
+                              }`
                             : null}
                         </Text>
                         <Text>
-                          {cellarConfig.customReward?.customRewardAPYTooltip ??
-                            `${cellarConfig.customReward?.showAPY ? `${cellarConfig.customReward.tokenDisplayName} ` : ""}Rewards APY ${
-                              extraRewardsApy?.formatted ?? rewardsApy?.formatted ?? "0.00%"
+                          {cellarConfig.customReward
+                            ?.customRewardAPYTooltip ??
+                            `${
+                              cellarConfig.customReward?.showAPY
+                                ? `${cellarConfig.customReward.tokenDisplayName} `
+                                : ""
+                            }Rewards APY ${
+                              extraRewardsApy?.formatted ??
+                              rewardsApy?.formatted ??
+                              "0.00%"
                             }`}
                         </Text>
                       </>
@@ -170,10 +211,15 @@ export const CellarStatsYield: FC<CellarStatsYieldProps> = ({
             >
               <HStack spacing={2} align="center">
                 <CardHeading>
-                  {isAlpha ? `${alphaStethI18n.netApyLabel}` : apyLabel(cellarConfig)}
+                  {isAlpha
+                    ? `${alphaStethI18n.netApyLabel}`
+                    : apyLabel(cellarConfig)}
                 </CardHeading>
-                <InformationIcon color="neutral.300" boxSize={3} />
-                {null}
+                {isAlpha ? (
+                  <AlphaApyTooltip />
+                ) : (
+                  <InformationIcon color="neutral.300" boxSize={3} />
+                )}
               </HStack>
             </Tooltip>
           </Box>

--- a/src/components/NetApyBreakdownModal.tsx
+++ b/src/components/NetApyBreakdownModal.tsx
@@ -1,0 +1,72 @@
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  ModalCloseButton,
+  Stack,
+  HStack,
+  Text,
+  useDisclosure,
+  Link as CLink,
+} from "@chakra-ui/react"
+import { alphaStethI18n } from "i18n/alphaSteth"
+
+export function useNetApyBreakdownModal() {
+  const controls = useDisclosure()
+  return controls
+}
+
+export function NetApyBreakdownModal({
+  isOpen,
+  onClose,
+  values = {
+    lidoBase: "~3.6%",
+    strategyBoost: "~7.2%",
+    netAfterFees: "~10.4%",
+  },
+}: {
+  isOpen: boolean
+  onClose: () => void
+  values?: { lidoBase?: string; strategyBoost?: string; netAfterFees?: string }
+}) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent bg="surface.bg" borderColor="surface.secondary" borderWidth={1}>
+        <ModalHeader>{alphaStethI18n.breakdownTitle}</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Stack spacing={3}>
+            <HStack justify="space-between">
+              <Text>{alphaStethI18n.breakdownItems.lidoBase}</Text>
+              <Text fontWeight={600}>{values.lidoBase}</Text>
+            </HStack>
+            <HStack justify="space-between">
+              <Text>{alphaStethI18n.breakdownItems.strategyBoost}</Text>
+              <Text fontWeight={600}>{values.strategyBoost}</Text>
+            </HStack>
+            <HStack justify="space-between">
+              <Text>{alphaStethI18n.breakdownItems.netAfterFees}</Text>
+              <Text fontWeight={700}>{values.netAfterFees}</Text>
+            </HStack>
+            <Text fontSize="xs" color="neutral.400">
+              {alphaStethI18n.breakdownPlaceholder}
+            </Text>
+            <CLink
+              href={alphaStethI18n.tooltipLinkHref}
+              isExternal
+              textDecor="underline"
+              fontSize="sm"
+            >
+              {alphaStethI18n.tooltipLinkText}
+            </CLink>
+          </Stack>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+

--- a/src/components/_cards/StrategyBreakdownCard/FAQAccordion.tsx
+++ b/src/components/_cards/StrategyBreakdownCard/FAQAccordion.tsx
@@ -10,9 +10,11 @@ import {
 } from "@chakra-ui/react"
 import { AiOutlineMinus, AiOutlinePlus } from "react-icons/ai"
 import parse from "html-react-parser"
+import { useEffect, useMemo, useState } from "react"
 
 interface Props extends AccordionProps {
   data: {
+    id?: string
     question: string
     answer: string
   }[]
@@ -20,12 +22,64 @@ interface Props extends AccordionProps {
 
 export const FAQAccordion: React.FC<Props> = ({ data, ...rest }) => {
   if (!data) return null
+
+  const [expandedIndex, setExpandedIndex] = useState<number[] | undefined>(
+    undefined
+  )
+
+  const getStableId = (q?: string, provided?: string) => {
+    if (provided) return provided
+    const text = (q || "").toLowerCase()
+    if (text.includes("what fees are applied")) return "faq-fees"
+    if (text.includes("what is apy for alpha steth")) return "faq-apy"
+    return undefined
+  }
+
+  const idToIndex = useMemo(() => {
+    const map = new Map<string, number>()
+    data.forEach((item, idx) => {
+      const stable = getStableId(item?.question, item?.id)
+      if (stable) map.set(stable.toLowerCase(), idx)
+    })
+    return map
+  }, [data])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const hash = window.location.hash?.slice(1).toLowerCase()
+    if (!hash) return
+    const idx = idToIndex.get(hash)
+    if (idx !== undefined) {
+      setExpandedIndex([idx])
+      setTimeout(() => {
+        document.getElementById(hash)?.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+        })
+      }, 50)
+    }
+  }, [idToIndex])
+
+  const handleChange = (val: number | number[]) => {
+    if (Array.isArray(val)) setExpandedIndex(val)
+    else setExpandedIndex([val])
+  }
+
   return (
-    <Accordion allowMultiple borderColor="purple.dark" {...rest}>
+    <Accordion
+      allowMultiple
+      borderColor="purple.dark"
+      index={expandedIndex}
+      onChange={handleChange as any}
+      {...rest}
+    >
       {data.map((item, index) => {
+        const stableId = getStableId(item?.question, item?.id)
         return (
           <AccordionItem
             key={index}
+            id={stableId}
+            data-faq-id={stableId}
             py={4}
             _first={{ borderTop: "none" }}
           >

--- a/src/components/_cards/StrategyBreakdownCard/FAQAccordion.tsx
+++ b/src/components/_cards/StrategyBreakdownCard/FAQAccordion.tsx
@@ -23,9 +23,9 @@ interface Props extends AccordionProps {
 export const FAQAccordion: React.FC<Props> = ({ data, ...rest }) => {
   if (!data) return null
 
-  const [expandedIndex, setExpandedIndex] = useState<number[] | undefined>(
-    undefined
-  )
+  const [expandedIndex, setExpandedIndex] = useState<
+    number[] | undefined
+  >(undefined)
 
   const getStableId = (q?: string, provided?: string) => {
     if (provided) return provided
@@ -46,16 +46,37 @@ export const FAQAccordion: React.FC<Props> = ({ data, ...rest }) => {
 
   useEffect(() => {
     if (typeof window === "undefined") return
-    const hash = window.location.hash?.slice(1).toLowerCase()
-    if (!hash) return
-    const idx = idToIndex.get(hash)
+    const url = new URL(window.location.href)
+    const hash = url.hash?.slice(1).toLowerCase()
+    const faqParam = url.searchParams.get("faq")?.toLowerCase()
+    const auto = url.searchParams.get("autoscroll") === "1"
+
+    const targetId =
+      hash === "faq-fees" || hash === "faq-apy"
+        ? hash
+        : faqParam === "fees"
+        ? "faq-fees"
+        : faqParam === "apy"
+        ? "faq-apy"
+        : undefined
+
+    if (!targetId) return
+    const idx = idToIndex.get(targetId)
     if (idx !== undefined) {
       setExpandedIndex([idx])
       setTimeout(() => {
-        document.getElementById(hash)?.scrollIntoView({
+        document.getElementById(targetId)?.scrollIntoView({
           behavior: "smooth",
           block: "start",
         })
+        if (auto) {
+          setTimeout(() => {
+            window.scrollTo({
+              top: document.documentElement.scrollHeight,
+              behavior: "smooth",
+            })
+          }, 150)
+        }
       }, 50)
     }
   }, [idToIndex])

--- a/src/components/_cards/StrategyBreakdownCard/index.tsx
+++ b/src/components/_cards/StrategyBreakdownCard/index.tsx
@@ -10,7 +10,7 @@ import {
   Text,
   useMediaQuery,
 } from "@chakra-ui/react"
-import { FC } from "react"
+import { FC, useEffect, useState } from "react"
 import { InnerCard } from "../InnerCard"
 import { tabPanelProps, tabProps } from "./styles"
 import { analytics } from "utils/analytics"
@@ -32,6 +32,17 @@ export const StrategyBreakdownCard: FC<StrategyBreakdownProps> = ({
   const { strategyBreakdown, faq } = cellarDataMap[cellarId]
   const [isMobile] = useMediaQuery("(max-width: 768px)")
 
+  const [tabIndex, setTabIndex] = useState(0)
+  const faqTabIndex = Object.keys(strategyBreakdown).length
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const hash = window.location.hash?.slice(1).toLowerCase()
+    if (hash === "faq-fees" || hash === "faq-apy") {
+      setTabIndex(faqTabIndex)
+    }
+  }, [faqTabIndex])
+
   return (
     <InnerCard
       pt={4}
@@ -39,7 +50,7 @@ export const StrategyBreakdownCard: FC<StrategyBreakdownProps> = ({
       pb={8}
       borderRadius={{ base: 0, sm: 16 }}
     >
-      <Tabs>
+      <Tabs index={tabIndex} onChange={setTabIndex}>
         <TabList
           borderBottomWidth={1}
           borderColor="purple.dark"

--- a/src/components/_modals/DepositModal/SommelierTab.tsx
+++ b/src/components/_modals/DepositModal/SommelierTab.tsx
@@ -57,6 +57,7 @@ import { useGeo } from "context/geoContext"
 import { useImportToken } from "hooks/web3/useImportToken"
 import { useStrategyData } from "data/hooks/useStrategyData"
 import { alphaStethI18n } from "i18n/alphaSteth"
+import { NetApyBreakdownModal, useNetApyBreakdownModal } from "components/NetApyBreakdownModal"
 import { useUserStrategyData } from "data/hooks/useUserStrategyData"
 import { useDepositModalStore } from "data/hooks/useDepositModalStore"
 import { FaExternalLinkAlt } from "react-icons/fa"
@@ -213,6 +214,15 @@ export const SommelierTab = ({
   )
   const isAlpha = id === config.CONTRACT.ALPHA_STETH.SLUG
   const netApy = strategyData?.baseApySumRewards?.formatted
+  const approxApy = (() => {
+    const raw = netApy
+    if (!raw) return undefined
+    const num = parseFloat(String(raw).replace(/%/g, ""))
+    if (Number.isNaN(num)) return raw
+    const oneDecimal = Math.round(num * 10) / 10
+    return `≈${oneDecimal.toFixed(1)}%`
+  })()
+  const breakdown = useNetApyBreakdownModal()
 
   const { userBalances } = useUserBalances()
 
@@ -1623,7 +1633,7 @@ export const SommelierTab = ({
           {isAlpha && (
             <VStack spacing={1} align="center">
               <Text as="span" fontSize="21px" fontWeight="bold">
-                {isLoading ? <Spinner /> : netApy ?? "--"}
+                {isLoading ? <Spinner /> : approxApy ?? netApy ?? "--"}
               </Text>
               <Tooltip
                 hasArrow
@@ -1640,14 +1650,28 @@ export const SommelierTab = ({
                 bg="surface.bg"
                 color="neutral.300"
               >
-                <HStack spacing={1} align="center">
+                <HStack spacing={2} align="center">
                   <CardHeading>{alphaStethI18n.netApyLabel}</CardHeading>
                   <InformationIcon color="neutral.300" boxSize={3} />
+                  <Text as="span" fontSize="xs" color="neutral.300">
+                    ({alphaStethI18n.estimatedTag}, variable)
+                  </Text>
                 </HStack>
               </Tooltip>
-              <Text fontSize="xs" color="neutral.400" textAlign="center" maxW="280px">
-                {alphaStethI18n.footnote}
-              </Text>
+              <VStack spacing={1}>
+                <Text fontSize="xs" color="neutral.400" textAlign="center" maxW="280px">
+                  {alphaStethI18n.inlineMicrocopy}
+                </Text>
+                <Text
+                  as="button"
+                  onClick={breakdown.onOpen}
+                  fontSize="xs"
+                  textDecor="underline"
+                  color="neutral.300"
+                >
+                  {alphaStethI18n.breakdownLink}
+                </Text>
+              </VStack>
             </VStack>
           )}
           <FormControl isInvalid={isError as boolean | undefined}>

--- a/src/components/_modals/DepositModal/SommelierTab.tsx
+++ b/src/components/_modals/DepositModal/SommelierTab.tsx
@@ -57,7 +57,7 @@ import { useGeo } from "context/geoContext"
 import { useImportToken } from "hooks/web3/useImportToken"
 import { useStrategyData } from "data/hooks/useStrategyData"
 import { alphaStethI18n } from "i18n/alphaSteth"
-import { formatAlphaStethNetApy } from "utils/alphaStethFormat"
+import { formatAlphaStethNetApyNoApprox } from "utils/alphaStethFormat"
 import { useUserStrategyData } from "data/hooks/useUserStrategyData"
 import { useDepositModalStore } from "data/hooks/useDepositModalStore"
 import { FaExternalLinkAlt } from "react-icons/fa"
@@ -217,7 +217,7 @@ export const SommelierTab = ({
   const approxApy = (() => {
     const raw = netApy
     if (!raw) return undefined
-    return formatAlphaStethNetApy(raw)
+    return formatAlphaStethNetApyNoApprox(raw)
   })()
 
   const { userBalances } = useUserBalances()
@@ -1654,11 +1654,7 @@ export const SommelierTab = ({
                   </Text>
                 </HStack>
               </Tooltip>
-              <VStack spacing={1}>
-                <Text fontSize="xs" color="neutral.400" textAlign="center" maxW="280px">
-                  {alphaStethI18n.inlineMicrocopy}
-                </Text>
-              </VStack>
+              {null}
             </VStack>
           )}
           <FormControl isInvalid={isError as boolean | undefined}>

--- a/src/components/_modals/DepositModal/SommelierTab.tsx
+++ b/src/components/_modals/DepositModal/SommelierTab.tsx
@@ -56,6 +56,7 @@ import { waitTime, depositAssetDefaultValue } from "data/uiConfig"
 import { useGeo } from "context/geoContext"
 import { useImportToken } from "hooks/web3/useImportToken"
 import { useStrategyData } from "data/hooks/useStrategyData"
+import { alphaStethI18n } from "i18n/alphaSteth"
 import { useUserStrategyData } from "data/hooks/useUserStrategyData"
 import { useDepositModalStore } from "data/hooks/useDepositModalStore"
 import { FaExternalLinkAlt } from "react-icons/fa"
@@ -210,6 +211,8 @@ export const SommelierTab = ({
     cellarConfig.cellar.address,
     cellarConfig.chain.id
   )
+  const isAlpha = id === config.CONTRACT.ALPHA_STETH.SLUG
+  const netApy = strategyData?.baseApySumRewards?.formatted
 
   const { userBalances } = useUserBalances()
 
@@ -1616,6 +1619,37 @@ export const SommelierTab = ({
           align="stretch"
           onSubmit={handleSubmit(onSubmit, onError)}
         >
+          {/* Alpha stETH: Net APY metric + tooltip */}
+          {isAlpha && (
+            <VStack spacing={1} align="center">
+              <Text as="span" fontSize="21px" fontWeight="bold">
+                {isLoading ? <Spinner /> : netApy ?? "--"}
+              </Text>
+              <Tooltip
+                hasArrow
+                placement="top"
+                label={
+                  <VStack align="start" spacing={1} maxW="280px">
+                    <Text fontWeight="semibold">{alphaStethI18n.tooltipTitle}</Text>
+                    <Text>{alphaStethI18n.tooltipBody}</Text>
+                    <Text as="a" href={alphaStethI18n.tooltipLinkHref} target="_blank" rel="noopener noreferrer" textDecor="underline">
+                      {alphaStethI18n.tooltipLinkText}
+                    </Text>
+                  </VStack>
+                }
+                bg="surface.bg"
+                color="neutral.300"
+              >
+                <HStack spacing={1} align="center">
+                  <CardHeading>{alphaStethI18n.netApyLabel}</CardHeading>
+                  <InformationIcon color="neutral.300" boxSize={3} />
+                </HStack>
+              </Tooltip>
+              <Text fontSize="xs" color="neutral.400" textAlign="center" maxW="280px">
+                {alphaStethI18n.footnote}
+              </Text>
+            </VStack>
+          )}
           <FormControl isInvalid={isError as boolean | undefined}>
             <ModalMenu
               depositTokens={depositTokens}

--- a/src/components/_modals/DepositModal/SommelierTab.tsx
+++ b/src/components/_modals/DepositModal/SommelierTab.tsx
@@ -57,6 +57,7 @@ import { useGeo } from "context/geoContext"
 import { useImportToken } from "hooks/web3/useImportToken"
 import { useStrategyData } from "data/hooks/useStrategyData"
 import { alphaStethI18n } from "i18n/alphaSteth"
+import { AlphaApyTooltip } from "components/alpha/AlphaApyTooltip"
 import { formatAlphaStethNetApyNoApprox } from "utils/alphaStethFormat"
 import { useUserStrategyData } from "data/hooks/useUserStrategyData"
 import { useDepositModalStore } from "data/hooks/useDepositModalStore"
@@ -1629,16 +1630,28 @@ export const SommelierTab = ({
           {isAlpha && (
             <VStack spacing={1} align="center">
               <Text as="span" fontSize="21px" fontWeight="bold">
-                {isLoading ? <Spinner /> : approxApy ?? netApy ?? "--"}
+                {isLoading ? (
+                  <Spinner />
+                ) : (
+                  approxApy ?? netApy ?? "--"
+                )}
               </Text>
               <Tooltip
                 hasArrow
                 placement="top"
                 label={
                   <VStack align="start" spacing={1} maxW="280px">
-                    <Text fontWeight="semibold">{alphaStethI18n.tooltipTitle}</Text>
+                    <Text fontWeight="semibold">
+                      {alphaStethI18n.tooltipTitle}
+                    </Text>
                     <Text>{alphaStethI18n.tooltipBody}</Text>
-                    <Text as="a" href={alphaStethI18n.tooltipLinkHref} target="_blank" rel="noopener noreferrer" textDecor="underline">
+                    <Text
+                      as="a"
+                      href={alphaStethI18n.tooltipLinkHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      textDecor="underline"
+                    >
                       {alphaStethI18n.tooltipLinkText}
                     </Text>
                   </VStack>
@@ -1647,11 +1660,10 @@ export const SommelierTab = ({
                 color="neutral.300"
               >
                 <HStack spacing={2} align="center">
-                  <CardHeading>{alphaStethI18n.netApyLabel}</CardHeading>
-                  <InformationIcon color="neutral.300" boxSize={3} />
-                  <Text as="span" fontSize="xs" color="neutral.300">
-                    ({alphaStethI18n.estimatedTag}, variable)
-                  </Text>
+                  <CardHeading>
+                    {alphaStethI18n.netApyLabel}
+                  </CardHeading>
+                  <AlphaApyTooltip />
                 </HStack>
               </Tooltip>
               {null}

--- a/src/components/_modals/DepositModal/SommelierTab.tsx
+++ b/src/components/_modals/DepositModal/SommelierTab.tsx
@@ -57,7 +57,7 @@ import { useGeo } from "context/geoContext"
 import { useImportToken } from "hooks/web3/useImportToken"
 import { useStrategyData } from "data/hooks/useStrategyData"
 import { alphaStethI18n } from "i18n/alphaSteth"
-import { AlphaApyTooltip } from "components/alpha/AlphaApyTooltip"
+import { AlphaApyPopover } from "components/alpha/AlphaApyPopover"
 import { formatAlphaStethNetApyNoApprox } from "utils/alphaStethFormat"
 import { useUserStrategyData } from "data/hooks/useUserStrategyData"
 import { useDepositModalStore } from "data/hooks/useDepositModalStore"
@@ -1630,42 +1630,12 @@ export const SommelierTab = ({
           {isAlpha && (
             <VStack spacing={1} align="center">
               <Text as="span" fontSize="21px" fontWeight="bold">
-                {isLoading ? (
-                  <Spinner />
-                ) : (
-                  approxApy ?? netApy ?? "--"
-                )}
+                {isLoading ? <Spinner /> : approxApy ?? netApy ?? "--"}
               </Text>
-              <Tooltip
-                hasArrow
-                placement="top"
-                label={
-                  <VStack align="start" spacing={1} maxW="280px">
-                    <Text fontWeight="semibold">
-                      {alphaStethI18n.tooltipTitle}
-                    </Text>
-                    <Text>{alphaStethI18n.tooltipBody}</Text>
-                    <Text
-                      as="a"
-                      href={alphaStethI18n.tooltipLinkHref}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      textDecor="underline"
-                    >
-                      {alphaStethI18n.tooltipLinkText}
-                    </Text>
-                  </VStack>
-                }
-                bg="surface.bg"
-                color="neutral.300"
-              >
-                <HStack spacing={2} align="center">
-                  <CardHeading>
-                    {alphaStethI18n.netApyLabel}
-                  </CardHeading>
-                  <AlphaApyTooltip />
-                </HStack>
-              </Tooltip>
+              <HStack spacing={2} align="center">
+                <CardHeading>{alphaStethI18n.netApyLabel}</CardHeading>
+                <AlphaApyPopover />
+              </HStack>
               {null}
             </VStack>
           )}

--- a/src/components/_modals/DepositModal/SommelierTab.tsx
+++ b/src/components/_modals/DepositModal/SommelierTab.tsx
@@ -57,7 +57,7 @@ import { useGeo } from "context/geoContext"
 import { useImportToken } from "hooks/web3/useImportToken"
 import { useStrategyData } from "data/hooks/useStrategyData"
 import { alphaStethI18n } from "i18n/alphaSteth"
-import { NetApyBreakdownModal, useNetApyBreakdownModal } from "components/NetApyBreakdownModal"
+import { formatAlphaStethNetApy } from "utils/alphaStethFormat"
 import { useUserStrategyData } from "data/hooks/useUserStrategyData"
 import { useDepositModalStore } from "data/hooks/useDepositModalStore"
 import { FaExternalLinkAlt } from "react-icons/fa"
@@ -217,12 +217,8 @@ export const SommelierTab = ({
   const approxApy = (() => {
     const raw = netApy
     if (!raw) return undefined
-    const num = parseFloat(String(raw).replace(/%/g, ""))
-    if (Number.isNaN(num)) return raw
-    const oneDecimal = Math.round(num * 10) / 10
-    return `≈${oneDecimal.toFixed(1)}%`
+    return formatAlphaStethNetApy(raw)
   })()
-  const breakdown = useNetApyBreakdownModal()
 
   const { userBalances } = useUserBalances()
 
@@ -1661,15 +1657,6 @@ export const SommelierTab = ({
               <VStack spacing={1}>
                 <Text fontSize="xs" color="neutral.400" textAlign="center" maxW="280px">
                   {alphaStethI18n.inlineMicrocopy}
-                </Text>
-                <Text
-                  as="button"
-                  onClick={breakdown.onOpen}
-                  fontSize="xs"
-                  textDecor="underline"
-                  color="neutral.300"
-                >
-                  {alphaStethI18n.breakdownLink}
                 </Text>
               </VStack>
             </VStack>

--- a/src/components/_pages/PageCellar.tsx
+++ b/src/components/_pages/PageCellar.tsx
@@ -147,7 +147,12 @@ const PageCellar: FC<PageCellarProps> = ({ id }) => {
               </Heading>
             </HStack>
           </VStack>
-          {isYieldStrategies && <CellarStatsYield cellarId={id} />}
+          {isYieldStrategies && (
+            <CellarStatsYield
+              cellarId={id}
+              alphaStethOverrides={id === utilConfig.CONTRACT.ALPHA_STETH.SLUG}
+            />
+          )}
 
           {isAutomatedPortfolio && (
             <CellarStatsAutomated cellarConfig={cellarConfig} />

--- a/src/components/_vaults/StrategyRow.tsx
+++ b/src/components/_vaults/StrategyRow.tsx
@@ -16,6 +16,7 @@ import { useDepositModalStore } from "data/hooks/useDepositModalStore"
 import { useUserStrategyData } from "data/hooks/useUserStrategyData"
 import { useStrategyData } from "data/hooks/useStrategyData"
 import KPIBox from "components/_vaults/KPIBox"
+import { config as utilConfig } from "utils/config"
 import ActionButton from "components/ui/ActionButton"
 
 type Vault = {
@@ -49,6 +50,15 @@ export default function StrategyRow({ vault }: { vault: Vault }) {
       ? parseFloat(vault?.baseApySumRewards?.value)
       : (vault?.baseApySumRewards?.value as number | undefined)
   const netFmt = vault?.baseApySumRewards?.formatted
+  const isAlpha = vault?.slug === utilConfig.CONTRACT.ALPHA_STETH.SLUG
+  const approxNetFmt = (() => {
+    const raw = netFmt
+    if (!raw) return undefined
+    const num = parseFloat(String(raw).replace(/%/g, ""))
+    if (Number.isNaN(num)) return raw
+    const oneDecimal = Math.round(num * 10) / 10
+    return `≈${oneDecimal.toFixed(1)}%`
+  })()
   const chainLabel = vault?.config?.chain?.displayName ?? "—"
   const chainLogo = (vault as any)?.config?.chain?.logoPath
   const launchDate = vault?.launchDate
@@ -212,8 +222,8 @@ export default function StrategyRow({ vault }: { vault: Vault }) {
             align="center"
           />
           <KPIBox
-            label="Net Rewards"
-            value={safeValue(netFmt)}
+            label={isAlpha ? "Net APY" : "Net Rewards"}
+            value={safeValue(isAlpha ? approxNetFmt ?? netFmt : netFmt)}
             align="right"
           />
         </Grid>

--- a/src/components/_vaults/StrategyRow.tsx
+++ b/src/components/_vaults/StrategyRow.tsx
@@ -230,38 +230,12 @@ export default function StrategyRow({ vault }: { vault: Vault }) {
               >
                 {safeValue(approxNetFmt ?? netFmt)}
               </Text>
-              <Tooltip
-                hasArrow
-                placement="top"
-                label={
-                  <VStack align="start" spacing={1} maxW="320px">
-                    <Text fontWeight="semibold">
-                      {alphaStethI18n.netApyLabel}
-                    </Text>
-                    <Text whiteSpace="pre-line">
-                      {alphaStethI18n.tooltipBody}
-                    </Text>
-                    <Text
-                      as="a"
-                      href={alphaStethI18n.tooltipLinkHref}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      textDecor="underline"
-                    >
-                      {alphaStethI18n.tooltipLinkText}
-                    </Text>
-                  </VStack>
-                }
-                bg="surface.bg"
-                color="neutral.300"
-              >
-                <HStack spacing={1} align="center">
-                  <Text fontSize="xs" color="neutral.400" isTruncated>
-                    Net APY
-                  </Text>
-                  <InformationIcon color="neutral.300" boxSize={3} />
-                </HStack>
-              </Tooltip>
+              <HStack spacing={1} align="center">
+                <Text fontSize="xs" color="neutral.400" isTruncated>
+                  Net APY
+                </Text>
+                <AlphaApyPopover />
+              </HStack>
             </VStack>
           ) : (
             <KPIBox

--- a/src/components/_vaults/StrategyRow.tsx
+++ b/src/components/_vaults/StrategyRow.tsx
@@ -16,6 +16,7 @@ import { useDepositModalStore } from "data/hooks/useDepositModalStore"
 import { useUserStrategyData } from "data/hooks/useUserStrategyData"
 import { useStrategyData } from "data/hooks/useStrategyData"
 import KPIBox from "components/_vaults/KPIBox"
+import { AlphaApyTooltip } from "components/alpha/AlphaApyTooltip"
 import ActionButton from "components/ui/ActionButton"
 import { config as utilConfig } from "utils/config"
 import { formatAlphaStethNetApyNoApprox } from "utils/alphaStethFormat"
@@ -88,9 +89,7 @@ export default function StrategyRow({ vault }: { vault: Vault }) {
     ?.userStrategyData?.userData?.netValue?.formatted
 
   const safeValue = (v?: string | number | null) =>
-    v === undefined || v === null || v === ""
-      ? "–"
-      : v
+    v === undefined || v === null || v === "" ? "–" : v
 
   // Helper text countdown (compact). Updates every second, rendered once below button
   const [remaining, setRemaining] = useState<string>("")
@@ -219,11 +218,20 @@ export default function StrategyRow({ vault }: { vault: Vault }) {
             value={safeValue(netValueFmt)}
             align="center"
           />
-          <KPIBox
-            label={isAlpha ? "Net APY" : "Net Rewards"}
-            value={safeValue(isAlpha ? approxNetFmt ?? netFmt : netFmt)}
-            align="right"
-          />
+          <Box position="relative">
+            <KPIBox
+              label={isAlpha ? "Net APY" : "Net Rewards"}
+              value={safeValue(
+                isAlpha ? approxNetFmt ?? netFmt : netFmt
+              )}
+              align="right"
+            />
+            {isAlpha && (
+              <Box position="absolute" top={0} right={0} transform="translateY(-50%)">
+                <AlphaApyTooltip />
+              </Box>
+            )}
+          </Box>
         </Grid>
 
         {/* Right column: chain + primary action with single helper */}
@@ -245,30 +253,30 @@ export default function StrategyRow({ vault }: { vault: Vault }) {
               fullWidth
               overrideChainId={(vault as any)?.config?.chain?.id}
             >
-            {isPreLaunch ? (
-              <ActionButton
-                variantStyle="primary"
-                size={{ base: "md", md: "md" }}
-                fullWidth
-                isDisabled
-                onClick={(e) => e.stopPropagation()}
-              >
-                Deposit
-              </ActionButton>
-            ) : (
-              <ActionButton
-                variantStyle="primary"
-                size={{ base: "md", md: "md" }}
-                fullWidth
-                onClick={(e) => {
-                  e.stopPropagation()
-                  if (!vault?.slug) return
-                  setIsOpen({ id: vault.slug, type: "deposit" })
-                }}
-              >
-                Deposit
-              </ActionButton>
-            )}
+              {isPreLaunch ? (
+                <ActionButton
+                  variantStyle="primary"
+                  size={{ base: "md", md: "md" }}
+                  fullWidth
+                  isDisabled
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  Deposit
+                </ActionButton>
+              ) : (
+                <ActionButton
+                  variantStyle="primary"
+                  size={{ base: "md", md: "md" }}
+                  fullWidth
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    if (!vault?.slug) return
+                    setIsOpen({ id: vault.slug, type: "deposit" })
+                  }}
+                >
+                  Deposit
+                </ActionButton>
+              )}
             </ConnectGate>
           </Box>
           {isPreLaunch && remaining && (

--- a/src/components/_vaults/StrategyRow.tsx
+++ b/src/components/_vaults/StrategyRow.tsx
@@ -9,6 +9,7 @@ import {
   Button,
   Avatar,
   Stack,
+  Tooltip,
 } from "@chakra-ui/react"
 import { useEffect, useMemo, useState } from "react"
 import ConnectGate from "components/wallet/ConnectGate"
@@ -21,6 +22,7 @@ import { KpiLabelWithInfo } from "components/alpha/KpiLabelWithInfo"
 import ActionButton from "components/ui/ActionButton"
 import { config as utilConfig } from "utils/config"
 import { formatAlphaStethNetApyNoApprox } from "utils/alphaStethFormat"
+import { InformationIcon } from "components/_icons"
 
 type Vault = {
   name?: string

--- a/src/components/_vaults/StrategyRow.tsx
+++ b/src/components/_vaults/StrategyRow.tsx
@@ -17,12 +17,11 @@ import { useDepositModalStore } from "data/hooks/useDepositModalStore"
 import { useUserStrategyData } from "data/hooks/useUserStrategyData"
 import { useStrategyData } from "data/hooks/useStrategyData"
 import KPIBox from "components/_vaults/KPIBox"
-import { AlphaApyTooltip } from "components/alpha/AlphaApyTooltip"
-import { KpiLabelWithInfo } from "components/alpha/KpiLabelWithInfo"
 import ActionButton from "components/ui/ActionButton"
 import { config as utilConfig } from "utils/config"
 import { formatAlphaStethNetApyNoApprox } from "utils/alphaStethFormat"
 import { InformationIcon } from "components/_icons"
+import { alphaStethI18n } from "i18n/alphaSteth"
 
 type Vault = {
   name?: string
@@ -236,8 +235,12 @@ export default function StrategyRow({ vault }: { vault: Vault }) {
                 placement="top"
                 label={
                   <VStack align="start" spacing={1} maxW="320px">
-                    <Text fontWeight="semibold">{alphaStethI18n.netApyLabel}</Text>
-                    <Text whiteSpace="pre-line">{alphaStethI18n.tooltipBody}</Text>
+                    <Text fontWeight="semibold">
+                      {alphaStethI18n.netApyLabel}
+                    </Text>
+                    <Text whiteSpace="pre-line">
+                      {alphaStethI18n.tooltipBody}
+                    </Text>
                     <Text
                       as="a"
                       href={alphaStethI18n.tooltipLinkHref}

--- a/src/components/_vaults/StrategyRow.tsx
+++ b/src/components/_vaults/StrategyRow.tsx
@@ -227,7 +227,7 @@ export default function StrategyRow({ vault }: { vault: Vault }) {
               align="right"
             />
             {isAlpha && (
-              <Box position="absolute" top={0} right={0} transform="translateY(-50%)">
+              <Box position="absolute" top={2} right={0} zIndex={1}>
                 <AlphaApyTooltip />
               </Box>
             )}

--- a/src/components/_vaults/StrategyRow.tsx
+++ b/src/components/_vaults/StrategyRow.tsx
@@ -16,9 +16,9 @@ import { useDepositModalStore } from "data/hooks/useDepositModalStore"
 import { useUserStrategyData } from "data/hooks/useUserStrategyData"
 import { useStrategyData } from "data/hooks/useStrategyData"
 import KPIBox from "components/_vaults/KPIBox"
-import { formatAlphaStethNetApy } from "utils/alphaStethFormat"
-import { config as utilConfig } from "utils/config"
 import ActionButton from "components/ui/ActionButton"
+import { config as utilConfig } from "utils/config"
+import { formatAlphaStethNetApyNoApprox } from "utils/alphaStethFormat"
 
 type Vault = {
   name?: string
@@ -55,7 +55,7 @@ export default function StrategyRow({ vault }: { vault: Vault }) {
   const approxNetFmt = (() => {
     const raw = netFmt
     if (!raw) return undefined
-    return formatAlphaStethNetApy(raw)
+    return formatAlphaStethNetApyNoApprox(raw)
   })()
   const chainLabel = vault?.config?.chain?.displayName ?? "—"
   const chainLogo = (vault as any)?.config?.chain?.logoPath

--- a/src/components/_vaults/StrategyRow.tsx
+++ b/src/components/_vaults/StrategyRow.tsx
@@ -17,6 +17,7 @@ import { useUserStrategyData } from "data/hooks/useUserStrategyData"
 import { useStrategyData } from "data/hooks/useStrategyData"
 import KPIBox from "components/_vaults/KPIBox"
 import { AlphaApyTooltip } from "components/alpha/AlphaApyTooltip"
+import { KpiLabelWithInfo } from "components/alpha/KpiLabelWithInfo"
 import ActionButton from "components/ui/ActionButton"
 import { config as utilConfig } from "utils/config"
 import { formatAlphaStethNetApyNoApprox } from "utils/alphaStethFormat"
@@ -218,20 +219,27 @@ export default function StrategyRow({ vault }: { vault: Vault }) {
             value={safeValue(netValueFmt)}
             align="center"
           />
-          <Box position="relative">
+          {isAlpha ? (
+            <VStack spacing={2} align="end" minW={0}>
+              <AlphaApyTooltip>
+                <KpiLabelWithInfo label="Net APY" aria-label="About Net APY" />
+              </AlphaApyTooltip>
+              <Text
+                fontSize={{ base: "xl", md: "2xl" }}
+                fontWeight={800}
+                lineHeight={1}
+                isTruncated
+              >
+                {safeValue(approxNetFmt ?? netFmt)}
+              </Text>
+            </VStack>
+          ) : (
             <KPIBox
-              label={isAlpha ? "Net APY" : "Net Rewards"}
-              value={safeValue(
-                isAlpha ? approxNetFmt ?? netFmt : netFmt
-              )}
+              label="Net Rewards"
+              value={safeValue(netFmt)}
               align="right"
             />
-            {isAlpha && (
-              <Box position="absolute" top={2} right={0} zIndex={1}>
-                <AlphaApyTooltip />
-              </Box>
-            )}
-          </Box>
+          )}
         </Grid>
 
         {/* Right column: chain + primary action with single helper */}

--- a/src/components/_vaults/StrategyRow.tsx
+++ b/src/components/_vaults/StrategyRow.tsx
@@ -221,9 +221,22 @@ export default function StrategyRow({ vault }: { vault: Vault }) {
           />
           {isAlpha ? (
             <VStack spacing={2} align="end" minW={0}>
-              <AlphaApyTooltip>
-                <KpiLabelWithInfo label="Net APY" aria-label="About Net APY" />
-              </AlphaApyTooltip>
+              <Tooltip
+                hasArrow
+                placement="top"
+                label={
+                  <Text>{safeValue(approxNetFmt ?? netFmt)}</Text>
+                }
+                bg="surface.bg"
+                color="neutral.300"
+              >
+                <HStack spacing={1} align="center">
+                  <Text fontSize="xs" color="neutral.400" isTruncated>
+                    Net APY
+                  </Text>
+                  <InformationIcon color="neutral.300" boxSize={3} />
+                </HStack>
+              </Tooltip>
               <Text
                 fontSize={{ base: "xl", md: "2xl" }}
                 fontWeight={800}

--- a/src/components/_vaults/StrategyRow.tsx
+++ b/src/components/_vaults/StrategyRow.tsx
@@ -22,6 +22,7 @@ import { config as utilConfig } from "utils/config"
 import { formatAlphaStethNetApyNoApprox } from "utils/alphaStethFormat"
 import { InformationIcon } from "components/_icons"
 import { alphaStethI18n } from "i18n/alphaSteth"
+import { AlphaApyPopover } from "components/alpha/AlphaApyPopover"
 
 type Vault = {
   name?: string

--- a/src/components/_vaults/StrategyRow.tsx
+++ b/src/components/_vaults/StrategyRow.tsx
@@ -16,6 +16,7 @@ import { useDepositModalStore } from "data/hooks/useDepositModalStore"
 import { useUserStrategyData } from "data/hooks/useUserStrategyData"
 import { useStrategyData } from "data/hooks/useStrategyData"
 import KPIBox from "components/_vaults/KPIBox"
+import { formatAlphaStethNetApy } from "utils/alphaStethFormat"
 import { config as utilConfig } from "utils/config"
 import ActionButton from "components/ui/ActionButton"
 
@@ -54,10 +55,7 @@ export default function StrategyRow({ vault }: { vault: Vault }) {
   const approxNetFmt = (() => {
     const raw = netFmt
     if (!raw) return undefined
-    const num = parseFloat(String(raw).replace(/%/g, ""))
-    if (Number.isNaN(num)) return raw
-    const oneDecimal = Math.round(num * 10) / 10
-    return `≈${oneDecimal.toFixed(1)}%`
+    return formatAlphaStethNetApy(raw)
   })()
   const chainLabel = vault?.config?.chain?.displayName ?? "—"
   const chainLogo = (vault as any)?.config?.chain?.logoPath

--- a/src/components/_vaults/StrategyRow.tsx
+++ b/src/components/_vaults/StrategyRow.tsx
@@ -223,11 +223,31 @@ export default function StrategyRow({ vault }: { vault: Vault }) {
           />
           {isAlpha ? (
             <VStack spacing={2} align="end" minW={0}>
+              <Text
+                fontSize={{ base: "xl", md: "2xl" }}
+                fontWeight={800}
+                lineHeight={1}
+                isTruncated
+              >
+                {safeValue(approxNetFmt ?? netFmt)}
+              </Text>
               <Tooltip
                 hasArrow
                 placement="top"
                 label={
-                  <Text>{safeValue(approxNetFmt ?? netFmt)}</Text>
+                  <VStack align="start" spacing={1} maxW="320px">
+                    <Text fontWeight="semibold">{alphaStethI18n.netApyLabel}</Text>
+                    <Text whiteSpace="pre-line">{alphaStethI18n.tooltipBody}</Text>
+                    <Text
+                      as="a"
+                      href={alphaStethI18n.tooltipLinkHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      textDecor="underline"
+                    >
+                      {alphaStethI18n.tooltipLinkText}
+                    </Text>
+                  </VStack>
                 }
                 bg="surface.bg"
                 color="neutral.300"
@@ -239,14 +259,6 @@ export default function StrategyRow({ vault }: { vault: Vault }) {
                   <InformationIcon color="neutral.300" boxSize={3} />
                 </HStack>
               </Tooltip>
-              <Text
-                fontSize={{ base: "xl", md: "2xl" }}
-                fontWeight={800}
-                lineHeight={1}
-                isTruncated
-              >
-                {safeValue(approxNetFmt ?? netFmt)}
-              </Text>
             </VStack>
           ) : (
             <KPIBox

--- a/src/components/alpha/AlphaApyPopover.tsx
+++ b/src/components/alpha/AlphaApyPopover.tsx
@@ -1,0 +1,71 @@
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverArrow,
+  PopoverBody,
+  Box,
+  Text,
+  Link as ChakraLink,
+  IconButton,
+  useDisclosure,
+} from "@chakra-ui/react"
+import NextLink from "next/link"
+import { InformationIcon } from "components/_icons"
+import { alphaStethI18n } from "i18n/alphaSteth"
+
+export function AlphaApyPopover() {
+  const d = useDisclosure()
+
+  return (
+    <Popover
+      isOpen={d.isOpen}
+      onOpen={d.onOpen}
+      onClose={d.onClose}
+      placement="top"
+      closeOnBlur
+      returnFocusOnClose
+      isLazy
+      modifiers={[
+        { name: "preventOverflow", options: { padding: 12, boundary: "viewport" } },
+        { name: "flip", options: { fallbackPlacements: ["top-start", "bottom", "right"] } },
+        { name: "offset", options: { offset: [0, 8] } },
+      ]}
+    >
+      <PopoverTrigger>
+        <IconButton
+          aria-label="About Net APY"
+          size="xs"
+          variant="ghost"
+          icon={<InformationIcon />}
+          onMouseEnter={d.onOpen}
+          onFocus={d.onOpen}
+          onClick={d.onOpen}
+        />
+      </PopoverTrigger>
+      <PopoverContent w="320px" _focus={{ outline: "none" }} zIndex="tooltip">
+        <PopoverArrow />
+        <PopoverBody>
+          <Box>
+            <Text fontWeight="semibold" mb={1}>
+              {alphaStethI18n.netApyLabel}
+            </Text>
+            <Text whiteSpace="pre-line">{alphaStethI18n.tooltipBody}</Text>
+            <ChakraLink
+              as={NextLink}
+              href={{ pathname: "/strategies/Alpha-stETH/manage", hash: "faq-apy" }}
+              display="inline-block"
+              mt={2}
+              textDecoration="underline"
+              onClick={d.onClose}
+            >
+              {alphaStethI18n.tooltipLinkText}
+            </ChakraLink>
+          </Box>
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+

--- a/src/components/alpha/AlphaApyPopover.tsx
+++ b/src/components/alpha/AlphaApyPopover.tsx
@@ -27,8 +27,16 @@ export function AlphaApyPopover() {
       returnFocusOnClose
       isLazy
       modifiers={[
-        { name: "preventOverflow", options: { padding: 12, boundary: "viewport" } },
-        { name: "flip", options: { fallbackPlacements: ["top-start", "bottom", "right"] } },
+        {
+          name: "preventOverflow",
+          options: { padding: 12, boundary: "viewport" },
+        },
+        {
+          name: "flip",
+          options: {
+            fallbackPlacements: ["top-start", "bottom", "right"],
+          },
+        },
         { name: "offset", options: { offset: [0, 8] } },
       ]}
     >
@@ -43,17 +51,27 @@ export function AlphaApyPopover() {
           onClick={d.onOpen}
         />
       </PopoverTrigger>
-      <PopoverContent w="320px" _focus={{ outline: "none" }} zIndex="tooltip">
+      <PopoverContent
+        w="320px"
+        _focus={{ outline: "none" }}
+        zIndex="tooltip"
+      >
         <PopoverArrow />
         <PopoverBody>
           <Box>
             <Text fontWeight="semibold" mb={1}>
               {alphaStethI18n.netApyLabel}
             </Text>
-            <Text whiteSpace="pre-line">{alphaStethI18n.tooltipBody}</Text>
+            <Text whiteSpace="pre-line">
+              {alphaStethI18n.tooltipBody}
+            </Text>
             <ChakraLink
               as={NextLink}
-              href={{ pathname: "/strategies/Alpha-stETH/manage", hash: "faq-apy" }}
+              href={{
+                pathname: "/strategies/Alpha-stETH/manage",
+                query: { tab: "faqs", faq: "apy", autoscroll: "1" },
+                hash: "faq-apy",
+              }}
               display="inline-block"
               mt={2}
               textDecoration="underline"
@@ -67,5 +85,3 @@ export function AlphaApyPopover() {
     </Popover>
   )
 }
-
-

--- a/src/components/alpha/AlphaApyTooltip.tsx
+++ b/src/components/alpha/AlphaApyTooltip.tsx
@@ -8,7 +8,7 @@ import {
 import { InformationIcon } from "components/_icons"
 import NextLink from "next/link"
 
-export function AlphaApyTooltip() {
+export function AlphaApyTooltip({ children }: { children?: React.ReactNode }) {
   return (
     <Tooltip
       hasArrow
@@ -18,8 +18,16 @@ export function AlphaApyTooltip() {
       closeOnScroll
       portalProps={{ appendToParentPortal: false }}
       modifiers={[
-        { name: "preventOverflow", options: { padding: 12, boundary: "viewport" } },
-        { name: "flip", options: { fallbackPlacements: ["right-start", "bottom", "top"] } },
+        {
+          name: "preventOverflow",
+          options: { padding: 12, boundary: "viewport" },
+        },
+        {
+          name: "flip",
+          options: {
+            fallbackPlacements: ["right-start", "bottom", "top"],
+          },
+        },
         { name: "offset", options: { offset: [0, 8] } },
       ]}
       zIndex="tooltip"
@@ -64,12 +72,14 @@ export function AlphaApyTooltip() {
         </Box>
       }
     >
-      <IconButton
-        aria-label="About Net APY"
-        size="xs"
-        variant="ghost"
-        icon={<InformationIcon />}
-      />
+      {children ?? (
+        <IconButton
+          aria-label="About Net APY"
+          size="xs"
+          variant="ghost"
+          icon={<InformationIcon />}
+        />
+      )}
     </Tooltip>
   )
 }

--- a/src/components/alpha/AlphaApyTooltip.tsx
+++ b/src/components/alpha/AlphaApyTooltip.tsx
@@ -1,5 +1,11 @@
-import { Box, Link, Text, Tooltip, IconButton } from "@chakra-ui/react"
-import { InfoOutlineIcon } from "@chakra-ui/icons"
+import {
+  Box,
+  Link,
+  Text,
+  Tooltip,
+  IconButton,
+} from "@chakra-ui/react"
+import { InformationIcon } from "components/_icons"
 import NextLink from "next/link"
 
 export function AlphaApyTooltip() {
@@ -17,20 +23,29 @@ export function AlphaApyTooltip() {
             7-day average APY after{" "}
             <Link
               as={NextLink}
-              href={{ pathname: "/strategies/Alpha-stETH/manage", hash: "faq-fees" }}
+              href={{
+                pathname: "/strategies/Alpha-stETH/manage",
+                hash: "faq-fees",
+              }}
               textDecoration="underline"
             >
               fees
             </Link>
           </Text>
-          <Text mt={1}>APY is the annual percentage yield including compounding.</Text>
           <Text mt={1}>
-            At Alpha stETH launch, and for the first 14 days, the daily APY will be displayed
-            instead of the 7-day APY due to insufficient historical data.
+            APY is the annual percentage yield including compounding.
+          </Text>
+          <Text mt={1}>
+            At Alpha stETH launch, and for the first 14 days, the
+            daily APY will be displayed instead of the 7-day APY due
+            to insufficient historical data.
           </Text>
           <Link
             as={NextLink}
-            href={{ pathname: "/strategies/Alpha-stETH/manage", hash: "faq-apy" }}
+            href={{
+              pathname: "/strategies/Alpha-stETH/manage",
+              hash: "faq-apy",
+            }}
             mt={2}
             display="inline-block"
             textDecoration="underline"
@@ -40,9 +55,12 @@ export function AlphaApyTooltip() {
         </Box>
       }
     >
-      <IconButton aria-label="About Net APY" size="xs" variant="ghost" icon={<InfoOutlineIcon />} />
+      <IconButton
+        aria-label="About Net APY"
+        size="xs"
+        variant="ghost"
+        icon={<InformationIcon />}
+      />
     </Tooltip>
   )
 }
-
-

--- a/src/components/alpha/AlphaApyTooltip.tsx
+++ b/src/components/alpha/AlphaApyTooltip.tsx
@@ -1,0 +1,48 @@
+import { Box, Link, Text, Tooltip, IconButton } from "@chakra-ui/react"
+import { InfoOutlineIcon } from "@chakra-ui/icons"
+import NextLink from "next/link"
+
+export function AlphaApyTooltip() {
+  return (
+    <Tooltip
+      hasArrow
+      placement="top"
+      openDelay={150}
+      label={
+        <Box maxW="300px">
+          <Text fontWeight="semibold" mb={1}>
+            Net APY
+          </Text>
+          <Text>
+            7-day average APY after{" "}
+            <Link
+              as={NextLink}
+              href={{ pathname: "/strategies/Alpha-stETH/manage", hash: "faq-fees" }}
+              textDecoration="underline"
+            >
+              fees
+            </Link>
+          </Text>
+          <Text mt={1}>APY is the annual percentage yield including compounding.</Text>
+          <Text mt={1}>
+            At Alpha stETH launch, and for the first 14 days, the daily APY will be displayed
+            instead of the 7-day APY due to insufficient historical data.
+          </Text>
+          <Link
+            as={NextLink}
+            href={{ pathname: "/strategies/Alpha-stETH/manage", hash: "faq-apy" }}
+            mt={2}
+            display="inline-block"
+            textDecoration="underline"
+          >
+            Learn more in Alpha stETH FAQ
+          </Link>
+        </Box>
+      }
+    >
+      <IconButton aria-label="About Net APY" size="xs" variant="ghost" icon={<InfoOutlineIcon />} />
+    </Tooltip>
+  )
+}
+
+

--- a/src/components/alpha/AlphaApyTooltip.tsx
+++ b/src/components/alpha/AlphaApyTooltip.tsx
@@ -12,8 +12,17 @@ export function AlphaApyTooltip() {
   return (
     <Tooltip
       hasArrow
-      placement="top"
-      openDelay={150}
+      placement="right"
+      gutter={10}
+      openDelay={120}
+      closeOnScroll
+      portalProps={{ appendToParentPortal: false }}
+      modifiers={[
+        { name: "preventOverflow", options: { padding: 12, boundary: "viewport" } },
+        { name: "flip", options: { fallbackPlacements: ["right-start", "bottom", "top"] } },
+        { name: "offset", options: { offset: [0, 8] } },
+      ]}
+      zIndex="tooltip"
       label={
         <Box maxW="300px">
           <Text fontWeight="semibold" mb={1}>

--- a/src/components/alpha/KpiLabelWithInfo.tsx
+++ b/src/components/alpha/KpiLabelWithInfo.tsx
@@ -1,0 +1,30 @@
+import { HStack, Text, IconButton } from "@chakra-ui/react"
+import { InformationIcon } from "components/_icons"
+
+type Props = {
+  label: string
+  onInfo?: (e: React.MouseEvent | React.KeyboardEvent) => void
+  "aria-label"?: string
+}
+
+export function KpiLabelWithInfo({ label, onInfo, ...a11y }: Props) {
+  return (
+    <HStack spacing="1" align="center">
+      <Text fontSize="xs" color="neutral.400">
+        {label}
+      </Text>
+      <IconButton
+        aria-label={(a11y as any)["aria-label"] ?? `About ${label}`}
+        size="xs"
+        variant="ghost"
+        icon={<InformationIcon />}
+        onClick={(e) => onInfo?.(e)}
+        onKeyDown={(e) => {
+          if ((e as any).key === "Enter" || (e as any).key === " ") onInfo?.(e)
+        }}
+      />
+    </HStack>
+  )
+}
+
+

--- a/src/data/strategies/alpha-steth.ts
+++ b/src/data/strategies/alpha-steth.ts
@@ -136,7 +136,8 @@ export const alphaSteth: CellarData = {
       answer: `Alpha STETH leverages an upgraded vault architecture to access new reward opportunities across a broader set of DeFi protocols. While TurboSTETH primarily focused on classic leverage loops, Alpha STETH incorporates advanced strategies including Morpho and Euler lending, ETH L2 and more - offering a more flexible and diversified approach to ETH-native reward strategies.`,
     },
     {
-      question: "What is APY for Alpha stETH, and how is it calculated?",
+      question:
+        "What is APY for Alpha stETH, and how is it calculated?",
       answer: `
       <div>
         <p>
@@ -144,6 +145,27 @@ export const alphaSteth: CellarData = {
         </p>
         <p style="font-style: italic; font-size: 0.875rem; color: #9CA3AF; margin-top: 8px;">
           Please note that APY figures are only estimates and subject to change at any time. Past performance is not a guarantee of future results. Rewards are influenced by factors outside the platform’s control, including changes to blockchain protocols and validator performance.
+        </p>
+      </div>
+      `,
+    },
+    {
+      question: "What fees are applied when I deposit into Alpha stETH?",
+      answer: `
+      <div>
+        <p>
+          When you deposit your tokens, you receive Alpha stETH vault tokens that represent your share of the vault. Your vault token balance never decreases to cover fees, instead, fees are reflected in the value of each vault token:
+        </p>
+        <ul style="margin-top:8px; padding-left: 1.25rem;">
+          <li style="margin-bottom:4px;">
+            <p><strong>Platform fee:</strong> 1% annually, pro-rated for the time your deposited tokens stay in the vault, is built into the token’s price.</p>
+          </li>
+          <li>
+            <p><strong>Performance fee:</strong> 10% of the yield is deducted from gains before they’re reflected in the token’s price.</p>
+          </li>
+        </ul>
+        <p style="margin-top:8px;">
+          So, while your token balance stays the same, the value per token adjusts to account for fees and performance.
         </p>
       </div>
       `,

--- a/src/data/strategies/alpha-steth.ts
+++ b/src/data/strategies/alpha-steth.ts
@@ -135,5 +135,18 @@ export const alphaSteth: CellarData = {
       question: "How is Alpha STETH different from TurboSTETH?",
       answer: `Alpha STETH leverages an upgraded vault architecture to access new reward opportunities across a broader set of DeFi protocols. While TurboSTETH primarily focused on classic leverage loops, Alpha STETH incorporates advanced strategies including Morpho and Euler lending, ETH L2 and more - offering a more flexible and diversified approach to ETH-native reward strategies.`,
     },
+    {
+      question: "What is APY for Alpha stETH, and how is it calculated?",
+      answer: `
+      <div>
+        <p>
+          APY is the annual percentage yield including compounding. In the context of Alpha stETH the APY calculation is the following: the vault’s rewards are derived from growth in its net asset value (NAV) over time. The NAV can increase through multiple use cases, such as staking, lending, providing liquidity on third-party providers. The user’s accrued rewards will depend on the portion of the vault that they hold.
+        </p>
+        <p style="font-style: italic; font-size: 0.875rem; color: #9CA3AF; margin-top: 8px;">
+          Please note that APY figures are only estimates and subject to change at any time. Past performance is not a guarantee of future results. Rewards are influenced by factors outside the platform’s control, including changes to blockchain protocols and validator performance.
+        </p>
+      </div>
+      `,
+    },
   ],
 }

--- a/src/i18n/alphaSteth.ts
+++ b/src/i18n/alphaSteth.ts
@@ -1,8 +1,8 @@
 export const alphaStethI18n = {
   netApyLabel: "Net APY",
   tooltipBody:
-    "APY is variable and may change over time. It includes Lido base rewards and strategy boost. Past performance does not guarantee future results.",
-  tooltipLinkText: "Learn more",
+    "7-day average APY after fees\n\nAPY is the annual percentage yield including compounding.\n\nAt Alpha stETH launch, and for the first 14 days, the daily APY will be displayed instead of the 7-day APY due to insufficient historical data.",
+  tooltipLinkText: "Learn more in Alpha stETH FAQ",
   tooltipLinkHref: "https://docs.veda.tech/alpha-steth/apy",
   estimatedTag: "Estimated",
   breakdownLink: "View breakdown",
@@ -15,5 +15,3 @@ export const alphaStethI18n = {
   breakdownPlaceholder:
     "Detailed breakdown coming soon. Values shown are placeholders.",
 }
-
-

--- a/src/i18n/alphaSteth.ts
+++ b/src/i18n/alphaSteth.ts
@@ -7,6 +7,18 @@ export const alphaStethI18n = {
   tooltipLinkHref: "https://docs.veda.tech",
   footnote:
     "APY estimates are based on current rewards from Lido ecosystem protocols. Past rewards do not guarantee future results.",
+  inlineMicrocopy:
+    "Based on current Lido ecosystem rewards. Not guaranteed.",
+  estimatedTag: "Estimated",
+  breakdownLink: "View breakdown",
+  breakdownTitle: "Net APY breakdown",
+  breakdownItems: {
+    lidoBase: "Lido base staking reward",
+    strategyBoost: "Strategy layer boost (Morpho, AAVE, Balancer)",
+    netAfterFees: "Net after fees",
+  },
+  breakdownPlaceholder:
+    "Detailed breakdown coming soon. Values shown are placeholders.",
 }
 
 

--- a/src/i18n/alphaSteth.ts
+++ b/src/i18n/alphaSteth.ts
@@ -1,0 +1,12 @@
+export const alphaStethI18n = {
+  netApyLabel: "Net APY",
+  tooltipTitle: "Net APY",
+  tooltipBody:
+    "Includes vault performance plus any rewards where applicable. Rewards are not guaranteed.",
+  tooltipLinkText: "Learn more",
+  tooltipLinkHref: "https://docs.veda.tech",
+  footnote:
+    "APY estimates are based on current rewards from Lido ecosystem protocols. Past rewards do not guarantee future results.",
+}
+
+

--- a/src/i18n/alphaSteth.ts
+++ b/src/i18n/alphaSteth.ts
@@ -1,14 +1,9 @@
 export const alphaStethI18n = {
   netApyLabel: "Net APY",
-  tooltipTitle: "Net APY",
   tooltipBody:
-    "Includes vault performance plus any rewards where applicable. Rewards are not guaranteed.",
+    "APY is variable and may change over time. It includes Lido base rewards and strategy boost. Past performance does not guarantee future results.",
   tooltipLinkText: "Learn more",
-  tooltipLinkHref: "https://docs.veda.tech",
-  footnote:
-    "APY estimates are based on current rewards from Lido ecosystem protocols. Past rewards do not guarantee future results.",
-  inlineMicrocopy:
-    "Based on current Lido ecosystem rewards. Not guaranteed.",
+  tooltipLinkHref: "https://docs.veda.tech/alpha-steth/apy",
   estimatedTag: "Estimated",
   breakdownLink: "View breakdown",
   breakdownTitle: "Net APY breakdown",

--- a/src/utils/alphaStethFormat.ts
+++ b/src/utils/alphaStethFormat.ts
@@ -11,4 +11,17 @@ export function formatAlphaStethNetApy(
   return `≈${rounded.toFixed(1)}%`
 }
 
+export function formatAlphaStethNetApyNoApprox(
+  value: number | string | null | undefined
+): string {
+  if (value == null) return "0.0%"
+  const n =
+    typeof value === "string"
+      ? parseFloat(value.replace(/%/g, ""))
+      : Number(value)
+  if (Number.isNaN(n)) return "0.0%"
+  const rounded = Math.round(n * 10) / 10
+  return `${rounded.toFixed(1)}%`
+}
+
 

--- a/src/utils/alphaStethFormat.ts
+++ b/src/utils/alphaStethFormat.ts
@@ -1,0 +1,14 @@
+export function formatAlphaStethNetApy(
+  value: number | string | null | undefined
+): string {
+  if (value == null) return "≈0.0%"
+  const n =
+    typeof value === "string"
+      ? parseFloat(value.replace(/%/g, ""))
+      : Number(value)
+  if (Number.isNaN(n)) return "≈0.0%"
+  const rounded = Math.round(n * 10) / 10
+  return `≈${rounded.toFixed(1)}%`
+}
+
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,6 +52,9 @@
       ],
       "utils/*": [
         "src/utils/*"
+      ],
+      "i18n/*": [
+        "src/i18n/*"
       ]
     },
     "resolveJsonModule": true,


### PR DESCRIPTION
Fixes #<ISSUE_NUMBER>

## Description

Describe big picture changes here. This will give viewers context for the changes.

## Changes

List any technical changes.

- [ ] Change 1

## Screenshots (if appropriate):

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- [ ] Step 1

## Links

Add links to Figma files, documentation, etc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced Net APY display for Alpha stETH across strategy rows, stats, and deposit flow, with an info popover/tooltip.
  - Added an APY breakdown view with stacked bar, legend, and contextual details.
  - Implemented a Net APY breakdown modal with default values.
  - Enabled deep-linking to FAQs and automatic tab selection via URL hash/params.
- Documentation
  - Expanded Alpha stETH FAQs with APY calculation/interpretation and fee details.
  - Added localized strings for Net APY labels, tooltips, breakdown items, and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->