### PR TITLE
Add specialized ETH value display for Alpha stETH

### DIFF
--- a/src/components/_cards/PortfolioCard/index.tsx
+++ b/src/components/_cards/PortfolioCard/index.tsx
@@ -191,6 +191,17 @@ export const PortfolioCard = (props: BoxProps) => {
   const baseAssetValue =
     userData?.userStrategyData.userData?.netValueInAsset?.formatted
 
+  const baseAssetValueRaw =
+    (userData?.userStrategyData.userData?.netValueInAsset as any)?.value as
+      | number
+      | undefined
+
+  const alphaEthValueFormatted = isAlphaSteth
+    ? (typeof baseAssetValueRaw === "number"
+        ? baseAssetValueRaw.toFixed(4)
+        : undefined)
+    : undefined
+
   const isActiveWithdrawRequest =
     useWithdrawRequestStatus(cellarConfig)
 
@@ -244,26 +255,39 @@ export const PortfolioCard = (props: BoxProps) => {
             </CardStat>
 
             {showNetValueInAsset(cellarConfig) && (
-              <CardStat
-                label="Base Asset Value"
-                tooltip={
-                  <Text>
-                    Total value of assets denominated in base asset
-                    <Avatar
-                      ml="-2.5px"
-                      boxSize={6}
-                      src={activeAsset?.src}
-                      name={activeAsset?.alt}
-                      borderWidth={2}
-                      borderColor="surface.bg"
-                      bg="surface.bg"
-                    />
-                    {activeAsset?.symbol}. excluding SOMM rewards
-                  </Text>
-                }
-              >
-                {isMounted && (isConnected ? baseAssetValue : "--")}
-              </CardStat>
+              isAlphaSteth ? (
+                <CardStat
+                  label="ETH Value"
+                  tooltip={
+                    <Text>
+                      Total value denominated in ETH (stETH ≈ ETH). Excludes SOMM rewards
+                    </Text>
+                  }
+                >
+                  {isMounted && (isConnected ? alphaEthValueFormatted ?? "..." : "--")}
+                </CardStat>
+              ) : (
+                <CardStat
+                  label="Base Asset Value"
+                  tooltip={
+                    <Text>
+                      Total value of assets denominated in base asset
+                      <Avatar
+                        ml="-2.5px"
+                        boxSize={6}
+                        src={activeAsset?.src}
+                        name={activeAsset?.alt}
+                        borderWidth={2}
+                        borderColor="surface.bg"
+                        bg="surface.bg"
+                      />
+                      {activeAsset?.symbol}. excluding SOMM rewards
+                    </Text>
+                  }
+                >
+                  {isMounted && (isConnected ? baseAssetValue : "--")}
+                </CardStat>
+              )
             )}
 
             <CardStat

--- a/src/components/_sidebar/PortofolioItem.tsx
+++ b/src/components/_sidebar/PortofolioItem.tsx
@@ -22,7 +22,6 @@ interface PortofolioItemProps extends StackProps {
   icon: string
   title: string
   netValueUsd: string
-  netValueInAsset: number
   tokenPrice: {
     value: number | string
     formatted: string
@@ -37,7 +36,6 @@ export const PortofolioItem: FC<PortofolioItemProps> = ({
   icon,
   title,
   netValueUsd,
-  netValueInAsset,
   tokenPrice,
   slug,
   description,
@@ -59,6 +57,22 @@ export const PortofolioItem: FC<PortofolioItemProps> = ({
   )
 
   const router = useRouter()
+
+  // Compute base-asset units directly from user's LP shares and per-share base-asset value
+  const sharesTokens = Number(lpTokenData?.formatted ?? 0)
+  const perShareInBase = (() => {
+    const raw = tokenPrice?.value as unknown
+    if (typeof raw === "number") return raw
+    const parsed = parseFloat(String(raw ?? "0").replace(/,/g, ""))
+    return Number.isFinite(parsed) ? parsed : 0
+  })()
+  const baseUnits = sharesTokens * perShareInBase
+  const isAlpha = slug === "Alpha-stETH"
+  const baseUnitsText = Number.isFinite(baseUnits)
+    ? baseUnits.toFixed(isAlpha ? 4 : 5)
+    : "0"
+  const assetLabel = isAlpha ? "ETH" : symbol
+
   return (
     <Tooltip
       label={description}
@@ -138,7 +152,7 @@ export const PortofolioItem: FC<PortofolioItemProps> = ({
                 ).toLocaleString()} Tokens`}
             </Text>
             <Text fontWeight={500} fontSize={12} color="neutral.400">
-              1 token = {Number(tokenPrice.value).toFixed(3)} {symbol}{" "}
+              1 token = {parseFloat(String(tokenPrice.value).replace(/,/g, "")).toFixed(3)} {symbol}{" "}
               ({formatUSD(coinGeckoPrice?.toString(), 4)})
             </Text>
           </VStack>
@@ -154,10 +168,9 @@ export const PortofolioItem: FC<PortofolioItemProps> = ({
             {netValueUsd}
           </Text>
           <Text fontWeight={500} fontSize={12} color="neutral.400">
-            {(netValueInAsset).toFixed(
-              showNetValueInAsset(cellarData.config) ? 5 : 2
-            )}
-            {` ${symbol}`}
+            {showNetValueInAsset(cellarData.config)
+              ? `${baseUnitsText} ${assetLabel}`
+              : ""}
           </Text>
         </VStack>
       </HStack>

--- a/src/components/_sidebar/YourPortofolio.tsx
+++ b/src/components/_sidebar/YourPortofolio.tsx
@@ -115,10 +115,6 @@ export const YourPortofolio = () => {
                           strategy.userStrategyData.userData
                             ?.netValue?.formatted ?? ""
                         }
-                        netValueInAsset={
-                          strategy.userStrategyData.userData
-                            ?.netValue?.value ?? 0
-                        }
                         tokenPrice={valueAndFormatted({
                           value:
                             strategy.userStrategyData.strategyData

--- a/src/components/alpha/AlphaApyPopover.tsx
+++ b/src/components/alpha/AlphaApyPopover.tsx
@@ -80,15 +80,7 @@ export function AlphaApyPopover() {
               7-day average APY after{" "}
               <ChakraLink
                 as={NextLink}
-                href={{
-                  pathname: "/strategies/Alpha-stETH/manage",
-                  query: {
-                    tab: "faqs",
-                    faq: "fees",
-                    autoscroll: "1",
-                  },
-                  hash: "faq-fees",
-                }}
+                href="/strategies/Alpha-stETH/manage?tab=faqs&faq=fees&autoscroll=1#faq-fees"
                 textDecoration="underline"
                 onClick={(e) => {
                   try {
@@ -114,11 +106,7 @@ export function AlphaApyPopover() {
             </Text>
             <ChakraLink
               as={NextLink}
-              href={{
-                pathname: "/strategies/Alpha-stETH/manage",
-                query: { tab: "faqs", faq: "apy", autoscroll: "1" },
-                hash: "faq-apy",
-              }}
+              href="/strategies/Alpha-stETH/manage?tab=faqs&faq=apy&autoscroll=1#faq-apy"
               display="inline-block"
               mt={2}
               textDecoration="underline"

--- a/src/components/alpha/AlphaApyTooltip.tsx
+++ b/src/components/alpha/AlphaApyTooltip.tsx
@@ -44,10 +44,7 @@ export function AlphaApyTooltip({
             7-day average APY after{" "}
             <Link
               as={NextLink}
-              href={{
-                pathname: "/strategies/Alpha-stETH/manage",
-                hash: "faq-fees",
-              }}
+              href="/strategies/Alpha-stETH/manage#faq-fees"
               textDecoration="underline"
             >
               fees
@@ -63,10 +60,7 @@ export function AlphaApyTooltip({
           </Text>
           <Link
             as={NextLink}
-            href={{
-              pathname: "/strategies/Alpha-stETH/manage",
-              hash: "faq-apy",
-            }}
+            href="/strategies/Alpha-stETH/manage#faq-apy"
             mt={2}
             display="inline-block"
             textDecoration="underline"

--- a/src/types/ambient/analytics.d.ts
+++ b/src/types/ambient/analytics.d.ts
@@ -1,0 +1,3 @@
+declare module "@vercel/analytics/react" {
+  export const Analytics: any
+}


### PR DESCRIPTION
The changes add a specialized display format for the Alpha stETH strategy's value, showing it in ETH terms rather than the generic "Base Asset Value" display used for other strategies. The commit also includes various link format simplifications and improved value formatting logic.

Fixes #<ISSUE_NUMBER>

## Description

Describe big picture changes here. This will give viewers context for the changes.

## Changes

List any technical changes.

- [ ] Change 1

## Screenshots (if appropriate):

## Testing Steps

As a reviewer, what steps should I take to verify this is working correctly?

- [ ] Step 1

## Links

Add links to Figma files, documentation, etc.
